### PR TITLE
feat: unscope yolo patch tools outside project root

### DIFF
--- a/src/file-tools.test.ts
+++ b/src/file-tools.test.ts
@@ -1,7 +1,15 @@
 // file-tools.test.ts — Tests for file tool implementations.
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, writeFileSync, readFileSync, rmSync, symlinkSync, mkdirSync } from "node:fs";
+import {
+  mkdtempSync,
+  writeFileSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  mkdirSync,
+  existsSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { createFileTools } from "./file-tools.js";
@@ -399,6 +407,89 @@ describe("file tools", () => {
       // relative(root, other) is absolute or starts with .. when outside — never startsWith(root+"/")
       const outside = resolve(projectDir, "..", "not-in-project.txt");
       expect(() => tools.read({ path: outside })).toThrow("Path outside project");
+    });
+  });
+
+  describe("unrestricted scope", () => {
+    let outsideDir: string;
+    let scope: { root: string; unrestricted: boolean };
+
+    beforeEach(() => {
+      outsideDir = mkdtempSync(join(tmpdir(), "codemode-unrestricted-"));
+      scope = { root: projectDir, unrestricted: true };
+      tools = createFileTools({ scope });
+    });
+
+    afterEach(() => {
+      rmSync(outsideDir, { recursive: true, force: true });
+    });
+
+    it("replace_in_file succeeds on absolute path outside root when unrestricted", () => {
+      const outsidePath = join(outsideDir, "scratch.txt");
+      writeFileSync(outsidePath, "hello outside");
+      const result = tools.replace_in_file({
+        path: outsidePath,
+        edits: [{ oldText: "outside", newText: "world" }],
+      });
+      expect(result).toContain("Replaced 1 occurrence");
+      expect(readFileSync(outsidePath, "utf-8")).toBe("hello world");
+    });
+
+    it("apply_patch succeeds on absolute path outside root when unrestricted", () => {
+      const outsidePath = join(outsideDir, "scratch.txt");
+      writeFileSync(outsidePath, "line1\nline2\nline3\n");
+      const result = tools.apply_patch({
+        patch: `--- a/${outsidePath}
++++ b/${outsidePath}
+@@ -1,3 +1,3 @@
+ line1
+-line2
++changed
+ line3
+`,
+      });
+      expect(result).toContain("Applied patch to 1 file");
+      expect(readFileSync(outsidePath, "utf-8")).toBe("line1\nchanged\nline3\n");
+    });
+
+    it("flipping unrestricted back to false restores Path outside project error", () => {
+      const outsidePath = join(outsideDir, "scratch.txt");
+      writeFileSync(outsidePath, "hello outside");
+      tools.replace_in_file({
+        path: outsidePath,
+        edits: [{ oldText: "outside", newText: "world" }],
+      });
+      expect(readFileSync(outsidePath, "utf-8")).toBe("hello world");
+
+      scope.unrestricted = false;
+      expect(() =>
+        tools.replace_in_file({
+          path: outsidePath,
+          edits: [{ oldText: "world", newText: "again" }],
+        }),
+      ).toThrow("Path outside project");
+      expect(() =>
+        tools.apply_patch({
+          patch: `--- a/${outsidePath}
++++ b/${outsidePath}
+@@ -1 +1 @@
+-hello world
++blocked
+`,
+        }),
+      ).toThrow("Path outside project");
+      expect(readFileSync(outsidePath, "utf-8")).toBe("hello world");
+    });
+
+    it("relative paths still resolve against root when unrestricted", () => {
+      writeFileSync(join(projectDir, "inside.txt"), "rel path");
+      const result = tools.replace_in_file({
+        path: "inside.txt",
+        edits: [{ oldText: "rel", newText: "root" }],
+      });
+      expect(result).toContain("Replaced 1 occurrence");
+      expect(readFileSync(join(projectDir, "inside.txt"), "utf-8")).toBe("root path");
+      expect(existsSync(join(outsideDir, "inside.txt"))).toBe(false);
     });
   });
 });

--- a/src/file-tools.ts
+++ b/src/file-tools.ts
@@ -1,14 +1,30 @@
 // file-tools.ts — Core file tool implementations (read, write, replace_in_file, apply_patch).
 //
 // These are host-side implementations that use Node.js fs directly.
-// Path validation ensures all operations stay within the project directory.
+// Path validation scopes operations to the project directory unless unrestricted (yolo).
 
 import { readFileSync, writeFileSync, mkdirSync, existsSync, realpathSync } from "node:fs";
 import { dirname, resolve, relative, isAbsolute, normalize, join, sep } from "node:path";
 
+/** Mutable path scope shared with the extension so mode flips take effect without re-registering tools. */
+export interface FileScope {
+  /** Base directory for relative paths (typically process.cwd() / project root). */
+  root: string;
+  /**
+   * When false, all paths must resolve inside root (default / on mode).
+   * When true, absolute paths may resolve anywhere; relative paths still use root (yolo mode).
+   */
+  unrestricted: boolean;
+}
+
 export interface FileToolsOptions {
-  /** Project root directory - all file operations are scoped to this directory */
-  projectRoot: string;
+  /**
+   * Project root directory. Used when `scope` is omitted; operations are always scoped
+   * (unrestricted: false). Prefer `scope` when the caller needs to flip unrestricted at runtime.
+   */
+  projectRoot?: string;
+  /** Mutable scope object. Read on every call so mode changes apply immediately. */
+  scope?: FileScope;
 }
 
 export interface ReadParams {
@@ -31,15 +47,24 @@ export interface ApplyPatchParams {
   patch: string;
 }
 
+function resolveScope(options: FileToolsOptions): FileScope {
+  if (options.scope) return options.scope;
+  if (options.projectRoot) {
+    return { root: options.projectRoot, unrestricted: false };
+  }
+  throw new Error("createFileTools requires scope or projectRoot");
+}
+
 /**
  * Create file tool implementations scoped to a project directory.
+ * Pass a mutable `scope` object to flip unrestricted at runtime (yolo mode).
  */
 export function createFileTools(options: FileToolsOptions) {
-  const { projectRoot } = options;
+  const scope = resolveScope(options);
 
   return {
     read(params: ReadParams): string {
-      const fullPath = validateAndResolvePath(params.path, projectRoot);
+      const fullPath = validateAndResolvePath(params.path, scope);
       const content = readFileSync(fullPath, "utf-8");
 
       // Handle line-based offset/limit
@@ -59,7 +84,7 @@ export function createFileTools(options: FileToolsOptions) {
     },
 
     write(params: WriteParams): void {
-      const fullPath = validateAndResolvePath(params.path, projectRoot);
+      const fullPath = validateAndResolvePath(params.path, scope);
 
       // Create parent directories if needed
       const dir = dirname(fullPath);
@@ -71,11 +96,11 @@ export function createFileTools(options: FileToolsOptions) {
     },
 
     apply_patch(params: ApplyPatchParams): string {
-      return applyUnifiedPatch(params.patch, projectRoot);
+      return applyUnifiedPatch(params.patch, scope);
     },
 
     replace_in_file(params: EditParams): string {
-      const fullPath = validateAndResolvePath(params.path, projectRoot);
+      const fullPath = validateAndResolvePath(params.path, scope);
       let content = readFileSync(fullPath, "utf-8");
 
       // Track replacement positions to detect overlaps
@@ -133,18 +158,25 @@ export function createFileTools(options: FileToolsOptions) {
 }
 
 /**
- * Validate and resolve a user-provided path to an absolute path within the project.
- * Throws if the path attempts to escape the project directory (including via symlinks).
+ * Validate and resolve a user-provided path to an absolute path.
  *
- * Policy: reject any path whose lexical or real (symlink-resolved) location is outside
- * the project root. For not-yet-existing targets, the nearest existing ancestor is
- * realpath'd and the remaining segments are re-checked lexically under that real base.
+ * When scope.unrestricted is false: reject any path whose lexical or real
+ * (symlink-resolved) location is outside the project root. For not-yet-existing
+ * targets, the nearest existing ancestor is realpath'd and the remaining segments
+ * are re-checked lexically under that real base.
+ *
+ * When scope.unrestricted is true: absolute paths resolve anywhere; relative paths
+ * still resolve against scope.root; no containment check (yolo mode).
  */
-function validateAndResolvePath(userPath: string, projectRoot: string): string {
-  const resolvedRoot = resolveRealOrNormalize(projectRoot);
+function validateAndResolvePath(userPath: string, scope: FileScope): string {
+  const resolvedRoot = resolveRealOrNormalize(scope.root);
   const candidate = isAbsolute(userPath)
     ? normalize(userPath)
     : normalize(join(resolvedRoot, userPath));
+
+  if (scope.unrestricted) {
+    return resolvePathUnrestricted(candidate);
+  }
 
   // Lexical containment before touching the filesystem (blocks .. traversal).
   assertPathInsideRoot(candidate, resolvedRoot, userPath);
@@ -154,6 +186,40 @@ function validateAndResolvePath(userPath: string, projectRoot: string): string {
   assertPathInsideRoot(realPath, resolvedRoot, userPath);
 
   return realPath;
+}
+
+/** Resolve path without project containment (absolute anywhere; relative already joined to root). */
+function resolvePathUnrestricted(candidate: string): string {
+  if (existsSync(candidate)) {
+    try {
+      return realpathSync(candidate);
+    } catch {
+      return normalize(resolve(candidate));
+    }
+  }
+
+  // Walk parents until one exists so new files land on the real ancestor path.
+  let probe = candidate;
+  const missing: string[] = [];
+  while (!existsSync(probe)) {
+    const parent = dirname(probe);
+    if (parent === probe) break;
+    missing.unshift(probe.slice(parent.length).replace(/^[\\/]/, ""));
+    probe = parent;
+  }
+
+  if (!existsSync(probe)) {
+    return normalize(resolve(candidate));
+  }
+
+  let realBase: string;
+  try {
+    realBase = realpathSync(probe);
+  } catch {
+    return normalize(resolve(candidate));
+  }
+
+  return missing.length > 0 ? join(realBase, ...missing) : realBase;
 }
 
 function resolveRealOrNormalize(path: string): string {
@@ -258,13 +324,13 @@ interface ParsedHunk {
   lines: string[];
 }
 
-function applyUnifiedPatch(patch: string, projectRoot: string): string {
+function applyUnifiedPatch(patch: string, scope: FileScope): string {
   const files = parsePatch(patch);
   if (files.length === 0) throw new Error("No file patches found in unified diff");
 
   const diffs: string[] = [];
   for (const file of files) {
-    const fullPath = validateAndResolvePath(file.path, projectRoot);
+    const fullPath = validateAndResolvePath(file.path, scope);
     const original = existsSync(fullPath) ? readFileSync(fullPath, "utf-8") : "";
     const updated = applyFilePatch(original, file);
     const dir = dirname(fullPath);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,5 +1,8 @@
 /* eslint-disable vitest/require-mock-type-parameters */
 import { beforeEach, describe, expect, test, vi } from "vitest";
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 type TestConfig = {
   mode: "off" | "on" | "yolo";
@@ -536,6 +539,93 @@ describe("codemodeExtension", () => {
       "codemode",
       "bash",
     ]);
+  });
+
+  test("yolo mode patch tools execute on absolute paths outside project root", async () => {
+    const outsideDir = mkdtempSync(join(tmpdir(), "codemode-index-yolo-"));
+    try {
+      const outsidePath = join(outsideDir, "scratch.txt");
+      writeFileSync(outsidePath, "hello outside");
+
+      const { default: codemodeExtension } = await import("./index.js");
+      const { pi, handlers, ctx } = createPiMock();
+      codemodeExtension(pi as never);
+      await handlers.get("session_start")?.({}, ctx);
+
+      const tools = pi.registerTool.mock.calls.map((call) => call[0]);
+      const replaceInFile = tools.find((tool) => tool.name === "replace_in_file");
+      const applyPatch = tools.find((tool) => tool.name === "apply_patch");
+      expect(replaceInFile).toBeDefined();
+      expect(applyPatch).toBeDefined();
+
+      const replaceResult = await replaceInFile.execute("call-1", {
+        path: outsidePath,
+        edits: [{ oldText: "outside", newText: "yolo" }],
+      });
+      expect(replaceResult.content[0].text).toContain("Replaced 1 occurrence");
+      expect(readFileSync(outsidePath, "utf-8")).toBe("hello yolo");
+
+      writeFileSync(outsidePath, "line1\nline2\nline3\n");
+      const patchResult = await applyPatch.execute("call-2", {
+        patch: `--- a/${outsidePath}
++++ b/${outsidePath}
+@@ -1,3 +1,3 @@
+ line1
+-line2
++changed
+ line3
+`,
+      });
+      expect(patchResult.content[0].text).toContain("Applied patch to 1 file");
+      expect(readFileSync(outsidePath, "utf-8")).toBe("line1\nchanged\nline3\n");
+    } finally {
+      rmSync(outsideDir, { recursive: true, force: true });
+    }
+  });
+
+  test("on mode patch tools reject absolute paths outside project root", async () => {
+    loadConfig.mockReturnValue({
+      mode: "on",
+      executor: { type: "quickjs", timeoutMs: 1234 },
+    });
+    const outsideDir = mkdtempSync(join(tmpdir(), "codemode-index-on-"));
+    try {
+      const outsidePath = join(outsideDir, "scratch.txt");
+      writeFileSync(outsidePath, "hello outside");
+
+      const { default: codemodeExtension } = await import("./index.js");
+      const { pi, handlers, ctx } = createPiMock();
+      codemodeExtension(pi as never);
+      await handlers.get("session_start")?.({}, ctx);
+
+      const tools = pi.registerTool.mock.calls.map((call) => call[0]);
+      const replaceInFile = tools.find((tool) => tool.name === "replace_in_file");
+      const applyPatch = tools.find((tool) => tool.name === "apply_patch");
+      expect(replaceInFile).toBeDefined();
+      expect(applyPatch).toBeDefined();
+
+      await expect(
+        replaceInFile.execute("call-1", {
+          path: outsidePath,
+          edits: [{ oldText: "outside", newText: "blocked" }],
+        }),
+      ).rejects.toThrow("Path outside project");
+
+      await expect(
+        applyPatch.execute("call-2", {
+          patch: `--- a/${outsidePath}
++++ b/${outsidePath}
+@@ -1 +1 @@
+-hello outside
++blocked
+`,
+        }),
+      ).rejects.toThrow("Path outside project");
+
+      expect(readFileSync(outsidePath, "utf-8")).toBe("hello outside");
+    } finally {
+      rmSync(outsideDir, { recursive: true, force: true });
+    }
   });
 
   test("session_shutdown closes MCP client", async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ import { createExecuteTool } from "./execute-tool.js";
 import { createMcpClient, type McpClient } from "./mcp-client.js";
 import { createToolBindings } from "./tool-bindings.js";
 import { loadConfig, type CodemodeConfig, type CodemodeMode } from "./config.js";
-import { createFileTools } from "./file-tools.js";
+import { createFileTools, type FileScope } from "./file-tools.js";
 import { generateNativeEditGuidance, generateSystemPromptAddition } from "./system-prompt.js";
 
 export default function codemodeExtension(pi: ExtensionAPI) {
@@ -110,9 +110,12 @@ export default function codemodeExtension(pi: ExtensionAPI) {
     });
   }
 
+  // --- Shared file scope (mutable unrestricted flag flipped in applyMode) ---
+  const fileScope: FileScope = { root: process.cwd(), unrestricted: false };
+
   // --- Register codemode tools ---
 
-  for (const tool of createTopLevelFileTools(process.cwd())) {
+  for (const tool of createTopLevelFileTools(fileScope)) {
     pi.registerTool(tool);
   }
 
@@ -189,6 +192,9 @@ export default function codemodeExtension(pi: ExtensionAPI) {
   // --- Helpers ---
 
   function applyMode(mode: CodemodeMode, ctx: ExtensionContext) {
+    // Patch tools share one registration; flip path scope with the mode.
+    fileScope.unrestricted = mode === "yolo";
+
     if (mode === "off") {
       deactivateCodemode();
       ctx.ui.notify("Codemode off — normal Pi tools active", "info");
@@ -285,8 +291,8 @@ export default function codemodeExtension(pi: ExtensionAPI) {
   }
 }
 
-function createTopLevelFileTools(projectRoot: string): ToolDefinition[] {
-  const fileTools = createFileTools({ projectRoot });
+function createTopLevelFileTools(scope: FileScope): ToolDefinition[] {
+  const fileTools = createFileTools({ scope });
   const textResult = (text: string) => ({ content: [{ type: "text", text }] });
 
   return [
@@ -294,7 +300,7 @@ function createTopLevelFileTools(projectRoot: string): ToolDefinition[] {
       name: "replace_in_file",
       label: "Replace in File",
       description:
-        "Replace text in a file using exact oldText/newText edits. Every oldText must match exactly once and edits must not overlap.",
+        "Replace text in a file using exact oldText/newText edits. Every oldText must match exactly once and edits must not overlap. Paths are scoped to the project root in on mode; in yolo mode absolute paths may reach anywhere on the host.",
       parameters: objectSchema({
         path: stringSchema(),
         edits: arraySchema(
@@ -314,7 +320,8 @@ function createTopLevelFileTools(projectRoot: string): ToolDefinition[] {
     {
       name: "apply_patch",
       label: "Apply Patch",
-      description: "Apply a text-only unified diff safely inside the project root.",
+      description:
+        "Apply a text-only unified diff. Paths are scoped to the project root in on mode; in yolo mode absolute paths may reach anywhere on the host (matching native bash reach).",
       parameters: objectSchema({
         patch: stringSchema(),
       }),

--- a/src/search.ts
+++ b/src/search.ts
@@ -58,7 +58,7 @@ const PI_TOOL_SEARCH_DESCRIPTIONS: Record<string, string> = {
   replace_in_file:
     "Exact search/replace file tool. Use for precise localized changes and replacements. oldText must match exactly once, replacements must be unique and non-overlapping, and nearby replacements should be merged. Use apply_patch for unified diffs.",
   apply_patch:
-    "Apply a text-only unified diff patch safely inside the project root. Useful for patch/diff-oriented edits and returns clear hunk failure diagnostics.",
+    "Apply a text-only unified diff patch. Paths are project-root scoped in on mode; yolo allows absolute paths anywhere. Useful for patch/diff-oriented edits and returns clear hunk failure diagnostics.",
 };
 
 let index: MiniSearch<SearchDoc> | null = null;

--- a/src/system-prompt.ts
+++ b/src/system-prompt.ts
@@ -166,6 +166,6 @@ export function generateEditGuidance(): string {
   return `\
 ### Edit guidance
 - File mutation is patch-only and outside codemode guest code.
-- Use the top-level visible patch editing tool for unified diffs scoped to the project root.
+- Use the top-level visible patch editing tool for unified diffs (project-root scoped in on mode; in yolo absolute paths may reach anywhere, matching bash).
 - Patch results should be rendered visibly in chat.`;
 }

--- a/src/tool-bindings.ts
+++ b/src/tool-bindings.ts
@@ -335,7 +335,7 @@ function describeBuiltinTools(toolName?: string): string {
     },
     apply_patch: {
       description:
-        "Top-level file tool. Apply a text-only unified diff safely inside the project root. Useful for patch/diff-oriented edits; returns clear hunk failure diagnostics.",
+        "Top-level file tool. Apply a text-only unified diff (project-root scoped in on mode; unscoped absolute paths in yolo). Useful for patch/diff-oriented edits; returns clear hunk failure diagnostics.",
       params: "{ patch: string }",
     },
     search_tools: {

--- a/src/type-generator.ts
+++ b/src/type-generator.ts
@@ -89,13 +89,13 @@ const fileToolDescriptors: Record<string, { description?: string; inputSchema: J
   },
   apply_patch: {
     description:
-      "Apply a text-only unified diff safely inside the project root. Use for patch/diff-oriented edits; hunk failures return diagnostics.",
+      "Apply a text-only unified diff (project-root scoped in on mode; unscoped in yolo). Use for patch/diff-oriented edits; hunk failures return diagnostics.",
     inputSchema: {
       type: "object",
       properties: {
         patch: {
           type: "string",
-          description: "Unified diff text to apply inside the project root",
+          description: "Unified diff text to apply",
         },
       },
       required: ["patch"],


### PR DESCRIPTION
## Summary
- In **yolo** mode, top-level `apply_patch` / `replace_in_file` can reach absolute paths outside the project root (same reach as native bash).
- **on** mode stays project-root scoped; native `edit` stays stripped in both modes.
- Shared mutable `FileScope` flips `unrestricted` on mode change without re-registering tools. Guest `codemode.*` bindings remain scoped.

Closes #51

## Test plan
- [x] `npm run check` (format, lint, build, full suite — 195 tests)
- [x] `npx vitest run src/file-tools.test.ts src/index.test.ts` (unrestricted unit + yolo/on wiring)
- [x] Manual smoke: yolo patch tools edit `/tmp`-style paths successfully
- [ ] CI green on PR