### PR TITLE
feat: write-lock on mode — strip native write/edit/bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,23 @@ Install the package in Pi as an extension package, then start Pi in a project as
 
 Useful controls:
 
-- `/codemode on` exposes `execute_tools` plus normal non-bash tools.
-- `/codemode yolo` exposes everything from `on` plus native `bash` when available.
-- `/codemode off` restores normal Pi tools.
+- `/codemode on` exposes `execute_tools` plus normal non-bash tools, write-locked to the project root.
+- `/codemode yolo` exposes everything from `on` plus native `bash` when available (the write escape hatch).
+- `/codemode off` restores normal Pi tools, including native `write`/`edit`/`bash`.
 - Bare `/codemode` toggles `off <-> on`.
+
+### Write-door matrix
+
+`on` mode is **write-locked**: native write-capable tools (`write`, `edit`, `bash`) are stripped from the active set. The only write doors are the root-scoped patch tools and allowlisted `cli.*` operations.
+
+| Door                                                       | `on`            | `yolo`                   |
+| ---------------------------------------------------------- | --------------- | ------------------------ |
+| codemode guest (in-guest `read` only; no mutation helpers) | read-only       | read-only                |
+| patch tools `replace_in_file` / `apply_patch`              | **root-scoped** | **unrestricted**         |
+| native `write`                                             | **DENY**        | **DENY**                 |
+| native `edit`                                              | **DENY**        | **DENY**                 |
+| native `bash`                                              | **DENY**        | **ALLOW** (escape hatch) |
+| host `cli.*`                                               | allowlisted ops | allowlisted ops          |
 
 ## The `execute_tools` shape
 
@@ -201,7 +214,7 @@ Default config:
 }
 ```
 
-`mode` can be `"on"`, `"yolo"`, or `"off"`. In `on`, Codemode exposes `execute_tools` plus normal non-bash tools. In `yolo`, native `bash` is included if Pi provides it; if not, codemode gracefully falls back to normal codemode tools and notifies you.
+`mode` can be `"on"`, `"yolo"`, or `"off"`. In `on`, Codemode exposes `execute_tools` plus normal non-bash tools, write-locked to the project root (native `write`/`edit`/`bash` are stripped; writes go through the root-scoped patch tools or allowlisted `cli.*`). In `yolo`, native `bash` is included if Pi provides it; if not, codemode gracefully falls back to normal codemode tools and notifies you. In `off`, normal Pi tools (including native `write`/`edit`/`bash`) are restored.
 
 Codemode-specific MCP servers and typed CLI capabilities can also be configured here:
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -111,7 +111,6 @@ describe("codemodeExtension", () => {
     expect(pi.getActiveTools).toHaveBeenCalled();
     expect(pi.setActiveTools).toHaveBeenCalledWith([
       "read",
-      "write",
       "replace_in_file",
       "apply_patch",
       "codemode",
@@ -176,13 +175,13 @@ describe("codemodeExtension", () => {
 
     expect(pi.setActiveTools).toHaveBeenCalledWith([
       "read",
-      "write",
       "replace_in_file",
       "apply_patch",
       "codemode",
     ]);
     expect(prompt.systemPrompt).toContain("## Code Mode (on)");
     expect(prompt.systemPrompt).toContain("native bash tool is not exposed");
+    expect(prompt.systemPrompt).toContain("Writes are restricted to the project root");
     expect(prompt.systemPrompt).toContain(
       "If the result you need is primarily stdout/stderr from one or more CLI calls, return a plain string",
     );
@@ -213,11 +212,33 @@ describe("codemodeExtension", () => {
     expect(pi.registerTool).toHaveBeenCalledWith(expect.objectContaining({ name: "apply_patch" }));
     expect(pi.setActiveTools).toHaveBeenCalledWith([
       "read",
-      "write",
       "replace_in_file",
       "apply_patch",
       "codemode",
     ]);
+  });
+
+  test("on mode is write-locked — native write/edit/bash are not active", async () => {
+    loadConfig.mockReturnValue({
+      mode: "on",
+      executor: { type: "quickjs", timeoutMs: 1234 },
+    });
+    const { default: codemodeExtension } = await import("./index.js");
+    const { pi, handlers, ctx } = createPiMock();
+    // Pi's base set includes all native write-capable tools.
+    pi.getActiveTools.mockReturnValue(["read", "write", "edit", "bash"]);
+    codemodeExtension(pi as never);
+
+    await handlers.get("session_start")?.({}, ctx);
+
+    const active = pi.setActiveTools.mock.calls.at(-1)?.[0] as string[];
+    expect(active).toContain("read");
+    expect(active).toContain("replace_in_file");
+    expect(active).toContain("apply_patch");
+    expect(active).toContain("codemode");
+    expect(active).not.toContain("write");
+    expect(active).not.toContain("edit");
+    expect(active).not.toContain("bash");
   });
 
   test("file edit tools render visible diffs in calls and results", async () => {
@@ -392,7 +413,6 @@ describe("codemodeExtension", () => {
 
     expect(pi.setActiveTools).toHaveBeenCalledWith([
       "read",
-      "write",
       "replace_in_file",
       "apply_patch",
       "codemode",
@@ -428,7 +448,6 @@ describe("codemodeExtension", () => {
 
     expect(pi.setActiveTools).toHaveBeenNthCalledWith(1, [
       "read",
-      "write",
       "replace_in_file",
       "apply_patch",
       "codemode",
@@ -436,7 +455,6 @@ describe("codemodeExtension", () => {
     ]);
     expect(pi.setActiveTools).toHaveBeenNthCalledWith(2, [
       "read",
-      "write",
       "replace_in_file",
       "apply_patch",
       "codemode",
@@ -448,7 +466,6 @@ describe("codemodeExtension", () => {
     expect(pi.setActiveTools.mock.calls[2]?.[0]).not.toContain("codemode");
     expect(pi.setActiveTools).toHaveBeenNthCalledWith(4, [
       "read",
-      "write",
       "replace_in_file",
       "apply_patch",
       "codemode",
@@ -533,7 +550,6 @@ describe("codemodeExtension", () => {
     expect(ctx.ui.notify).not.toHaveBeenCalledWith("Usage: /codemode [on|yolo|off]", "warning");
     expect(pi.setActiveTools).toHaveBeenCalledWith([
       "read",
-      "write",
       "replace_in_file",
       "apply_patch",
       "codemode",

--- a/src/index.ts
+++ b/src/index.ts
@@ -218,6 +218,7 @@ export default function codemodeExtension(pi: ExtensionAPI) {
     const tools = originalTools.filter(
       (tool) =>
         tool !== "bash" &&
+        tool !== "write" &&
         // Do not activate an older execute_tools registration if a previous/other extension provides one.
         // This package intentionally registers only the Pi-facing codemode tool.
         tool !== "execute_tools" &&
@@ -238,7 +239,7 @@ export default function codemodeExtension(pi: ExtensionAPI) {
   }
 
   function deactivateCodemode() {
-    // When leaving on/yolo, put back tools those modes strip (bash, edit).
+    // When leaving on/yolo, put back tools those modes strip (bash, edit, write).
     // When already starting in off, only drop codemode-owned names — don't invent tools.
     const leavingCodemode = currentMode !== "off";
     const desired = nativeToolsForOffMode({ restoreStripped: leavingCodemode });
@@ -257,7 +258,7 @@ export default function codemodeExtension(pi: ExtensionAPI) {
 
   /**
    * Tools to activate when codemode is off: session baseline minus codemode-owned tools.
-   * Optionally restore host tools that codemode modes intentionally strip (bash, edit),
+   * Optionally restore host tools that codemode modes intentionally strip (bash, edit, write),
    * even if the session_start snapshot omitted them (common with partial active sets).
    */
   function nativeToolsForOffMode(options: { restoreStripped: boolean }): string[] {
@@ -276,8 +277,8 @@ export default function codemodeExtension(pi: ExtensionAPI) {
 
     const restored = [...baseline];
     if (options.restoreStripped) {
-      // Modes strip bash/edit; put them back if the host still provides them.
-      for (const name of ["bash", "edit"] as const) {
+      // Modes strip bash/edit/write; put them back if the host still provides them.
+      for (const name of ["bash", "edit", "write"] as const) {
         if (available.has(name) && !restored.includes(name)) {
           restored.push(name);
         }

--- a/src/system-prompt.ts
+++ b/src/system-prompt.ts
@@ -13,7 +13,7 @@ export function generateSystemPromptAddition(
   const modeGuidance =
     mode === "yolo"
       ? "In yolo mode, native bash is available and has broader host access. Prefer codemode for structured tool use and use bash for shell-heavy one-offs."
-      : "In normal codemode, use codemode workflows and top-level non-bash tools. The native bash tool is not exposed.";
+      : "In normal codemode, use codemode workflows and top-level non-bash tools. The native bash tool is not exposed. Writes are restricted to the project root and go through the root-scoped patch tools (replace_in_file / apply_patch); native write/edit/bash are not exposed.";
   return `\
 ## Code Mode (${mode})
 


### PR DESCRIPTION
## Summary
Implements issue #34. `on` mode is now **write-locked**: native write-capable tools (`write`, `edit`, `bash`) are stripped from the active set, so the only write doors are the root-scoped patch tools (`replace_in_file` / `apply_patch`) and allowlisted `cli.*` operations.

## Changes
- `src/index.ts` — `codemodeTools()` filters out `write` in both `on` and `yolo` (yolo keeps `bash` as the escape hatch); `nativeToolsForOffMode()` restores `write` (plus `edit`/`bash`) when leaving codemode to `off`.
- `src/system-prompt.ts` — `on`-mode guidance states writes are project-root-scoped via patch tools; native write/edit/bash are not exposed.
- `README.md` — documents the write-door matrix for `on` vs `yolo`.
- `src/index.test.ts` — dropped `write` from on/yolo active-set expectations; added regression test "on mode is write-locked — native write/edit/bash are not active"; added prompt-wording assertion.

## Write-door matrix
| Door | `on` | `yolo` |
| --- | --- | --- |
| codemode guest (in-guest `read` only) | read-only | read-only |
| patch tools `replace_in_file` / `apply_patch` | **root-scoped** | **unrestricted** |
| native `write` | **DENY** | **DENY** |
| native `edit` | **DENY** | **DENY** |
| native `bash` | **DENY** | **ALLOW** (escape hatch) |
| host `cli.*` | allowlisted ops | allowlisted ops |

## Verification
- `npm run check` passes (format, lint, build, 196 tests).
- Smoke-tested in `on` (write/edit/bash stripped; patch tools root-scoped) and `yolo` (bash escape hatch available; write/edit stripped).
- Grok initial review: APPROVED (zero BLOCKERs). Re-review of delta: APPROVED.

Closes #34