### PR TITLE
feat: expose MCP tools under mcp namespace

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ Before expanding executor features, keep these behaviors covered by tests:
 - awaits one async host tool call
 - resolves many concurrent host tool calls via `Promise.all`
 - propagates rejected host calls to the guest promise
-- supports nested MCP-style namespaces, e.g. `codemode.github.search_issues(...)`
+- supports nested MCP-style namespaces, e.g. `mcp.github.search_issues(...)`
 - times out runaway code
 - does not expose Node or host globals such as `process`, `require`, filesystem, environment, network, or subprocess APIs
 - releases QuickJS runtime/context memory cleanly after execution

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Generated code only receives explicit globals:
 - `codemode.describe_tools({ namespace, tool? })` shows MCP namespace/tool details.
 - `codemode.plan_npm_script({ script })` decomposes a safe package script into visible `cli.*` calls without executing it.
 - `codemode.run_npm_script({ script, verbose? })` decomposes a safe package script, shows the plan, and executes only the surfaced `cli.*` calls.
-- `codemode.<namespace>.<tool>(args)` calls configured MCP tools.
+- `mcp.<namespace>.<tool>(args)` calls configured MCP tools. The legacy `codemode.<namespace>.<tool>(args)` form remains supported.
 - `cli.<tool>.<operation>(args)` calls configured typed CLI capabilities.
 - `print(...args)` emits result output.
 - `π.key` reads string constants passed in the `strings` parameter.
@@ -179,7 +179,7 @@ Operation-specific timeouts can be configured with object-form `operations`:
 
 ## MCP discovery workflow
 
-MCP tools are exposed under `codemode.*` only:
+MCP tools are exposed under the preferred `mcp.*` namespace. The legacy `codemode.<namespace>.<tool>()` form remains supported:
 
 ```ts
 const github = await codemode.describe_tools({ namespace: "github" });
@@ -188,7 +188,7 @@ print(github);
 const details = await codemode.describe_tools({ namespace: "github", tool: "search_issues" });
 print(details);
 
-return await codemode.github.search_issues({ query: "is:open label:bug" });
+return await mcp.github.search_issues({ query: "is:open label:bug" });
 ```
 
 Use `codemode.list_mcp_servers()` to see available namespaces and `codemode.list_tools({ namespace })` to page through large cached tool lists. Use `codemode.search_tools({ query })` when you do not know the namespace or exact tool name.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,7 +9,7 @@ Pi Codemode exposes one primary Pi tool, `execute_tools`, where the model writes
 - codemode-only MCP tools
 - discovery helpers such as `search_tools` and `describe_tools`
 
-The generated API exposes Pi-aligned top-level file helpers plus `codemode.*` for discovery and MCP namespaces:
+The generated API exposes Pi-aligned top-level file helpers, `codemode.*` for built-ins and discovery, and `mcp.*` for MCP namespaces:
 
 ```ts
 const [pkg, readme] = await Promise.all([
@@ -36,14 +36,14 @@ Pi plugin
   -> Pi-native execute_tools wrapper
   -> QuickJS sandbox executor
   -> async host-function bridge
-  -> Pi safe tools + host cli.* + codemode-only MCP
+  -> Pi safe tools + host cli.* + codemode-only mcp.*
 ```
 
 Deno remains an optional/future executor behind the same interface. Node VM is intentionally skipped for now.
 
 ## Executor choices
 
-QuickJS is the default MVP executor (`executor.type: "quickjs"`). It runs code in an embedded QuickJS runtime with an explicit host bridge and no direct Node, filesystem, environment, network, or subprocess globals. Tool access is limited to injected globals (`codemode`, `$`, `shell`, `print`, and `π`).
+QuickJS is the default MVP executor (`executor.type: "quickjs"`). It runs code in an embedded QuickJS runtime with an explicit host bridge and no direct Node, filesystem, environment, network, or subprocess globals. Tool access is limited to injected globals (`codemode`, `mcp`, `cli`, `print`, and `π`).
 
 Deno is still available as an optional executor (`executor.type: "deno"`) for future compatibility and experiments, but it is dormant unless selected in configuration. Configuration is loaded from `~/.pi/agent/codemode.json` and `$PROJECT/.pi/codemode.json`, with project settings taking precedence. When selected, Deno stays behind the shared executor interface and launches a no-permission subprocess. If the configured executable is missing or cannot be spawned, `execute_tools` reports a clear configured-executor-unavailable runtime error instead of silently falling back.
 
@@ -91,9 +91,9 @@ The executor should:
 2. transform/strip TypeScript
 3. evaluate JavaScript in QuickJS
 4. inject globals:
-   - `codemode`
-   - `$`
-   - `shell`
+   - `codemode` (built-ins and legacy MCP aliases)
+   - `mcp` (preferred MCP namespaces)
+   - `cli` (host CLI wrappers)
    - `print`
    - `π`
 5. route all host capabilities through an async host-function bridge
@@ -155,7 +155,7 @@ Useful modules/designs to adapt:
 
 Things intentionally changed:
 
-- `tools.*` API -> `codemode.*`
+- `tools.*` API -> `codemode.*` built-ins plus `mcp.*` MCP namespaces
 - free-form shell backends -> allowlisted host `cli.*` only
 - Node `vm` executor -> QuickJS target, Deno optional
 - old JSON Schema -> TypeScript generator -> Cloudflare helper where suitable
@@ -170,7 +170,7 @@ Design:
 - expose tools in generated code through nested namespaces:
 
 ```ts
-await codemode.github.search_issues({ query: "is:open label:bug" });
+await mcp.github.search_issues({ query: "is:open label:bug" });
 ```
 
 - connect MCP servers lazily on first actual call

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@jitl/quickjs-singlefile-mjs-release-sync": "^0.32.0",
+        "ajv": "^8.20.0",
         "minisearch": "^7.2.0",
         "pi-mcp-adapter": "2.5.4",
         "quickjs-emscripten-core": "^0.32.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   },
   "dependencies": {
     "@jitl/quickjs-singlefile-mjs-release-sync": "^0.32.0",
+    "ajv": "^8.20.0",
     "minisearch": "^7.2.0",
     "pi-mcp-adapter": "2.5.4",
     "quickjs-emscripten-core": "^0.32.0",

--- a/src/adapter-shims/config.d.ts
+++ b/src/adapter-shims/config.d.ts
@@ -1,0 +1,2 @@
+import type { McpConfig } from "./types.js";
+export function loadMcpConfig(overridePath?: string): McpConfig;

--- a/src/adapter-shims/metadata-cache.d.ts
+++ b/src/adapter-shims/metadata-cache.d.ts
@@ -1,0 +1,29 @@
+import type { McpTool, McpResource, ServerEntry } from "./types.js";
+
+export interface CachedTool {
+  name: string;
+  description?: string;
+  inputSchema?: unknown;
+}
+export interface CachedResource {
+  uri: string;
+  name: string;
+  description?: string;
+}
+export interface ServerCacheEntry {
+  configHash: string;
+  tools: CachedTool[];
+  resources: CachedResource[];
+  cachedAt: number;
+}
+export interface MetadataCache {
+  version: number;
+  servers: Record<string, ServerCacheEntry>;
+}
+
+export function loadMetadataCache(): MetadataCache | null;
+export function saveMetadataCache(cache: MetadataCache): void;
+export function computeServerHash(definition: ServerEntry): string;
+export function isServerCacheValid(entry: ServerCacheEntry, definition: ServerEntry): boolean;
+export function serializeTools(tools: McpTool[]): CachedTool[];
+export function serializeResources(resources: McpResource[]): CachedResource[];

--- a/src/adapter-shims/server-manager.d.ts
+++ b/src/adapter-shims/server-manager.d.ts
@@ -1,0 +1,22 @@
+import type { McpContent, McpTool, McpResource, ServerEntry } from "./types.js";
+
+export interface ServerConnection {
+  client: {
+    callTool(args: {
+      name: string;
+      arguments: unknown;
+    }): Promise<{ content?: McpContent[]; isError?: boolean }>;
+  };
+  tools: McpTool[];
+  resources: McpResource[];
+  status: "connected" | "closed" | "needs-auth";
+}
+
+export class McpServerManager {
+  connect(name: string, definition: ServerEntry): Promise<ServerConnection>;
+  getConnection(name: string): ServerConnection | undefined;
+  touch(name: string): void;
+  incrementInFlight(name: string): void;
+  decrementInFlight(name: string): void;
+  closeAll(): Promise<void>;
+}

--- a/src/adapter-shims/tool-registrar.d.ts
+++ b/src/adapter-shims/tool-registrar.d.ts
@@ -1,0 +1,2 @@
+import type { McpContent, ContentBlock } from "./types.js";
+export function transformMcpContent(content: McpContent[]): ContentBlock[];

--- a/src/adapter-shims/types.d.ts
+++ b/src/adapter-shims/types.d.ts
@@ -1,0 +1,60 @@
+// Local type shims for pi-mcp-adapter subpath imports.
+//
+// pi-mcp-adapter ships raw .ts sources with no stable public entrypoint. Importing
+// its subpaths directly makes TypeScript follow the whole import graph into
+// adapter internals (and newer @earendil-works references), which breaks the build
+// on some adapter versions. These shims type only the surface we use, and are
+// wired via tsconfig "paths" so TypeScript never resolves into the adapter's
+// source internals. Runtime still resolves to the real adapter package.
+
+export interface McpContent {
+  type: "text" | "image" | "audio" | "resource" | "resource_link";
+  text?: string;
+  data?: string;
+  mimeType?: string;
+  resource?: { uri: string; text?: string; blob?: string };
+  uri?: string;
+  name?: string;
+  description?: string;
+}
+
+export type ContentBlock =
+  | { type: "text"; text: string }
+  | { type: "image"; data: string; mimeType: string };
+
+export interface McpTool {
+  name: string;
+  title?: string;
+  description?: string;
+  inputSchema?: unknown;
+}
+
+export interface McpResource {
+  uri: string;
+  name: string;
+  description?: string;
+  mimeType?: string;
+}
+
+export interface ServerEntry {
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  cwd?: string;
+  url?: string;
+  headers?: Record<string, string>;
+  auth?: "oauth" | "bearer" | false;
+  bearerToken?: string;
+  bearerTokenEnv?: string;
+  lifecycle?: "keep-alive" | "lazy" | "eager";
+  idleTimeout?: number;
+  exposeResources?: boolean;
+  directTools?: boolean | string[];
+  excludeTools?: string[];
+  debug?: boolean;
+}
+
+export interface McpConfig {
+  mcpServers: Record<string, ServerEntry>;
+  settings?: { toolPrefix?: "server" | "none" | "short" };
+}

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -9,7 +9,7 @@ vi.mock("@mariozechner/pi-tui", () => ({
     constructor(public text: string) {}
   },
 }));
-import { buildCliArgv, createCliBindings } from "./cli.js";
+import { buildCliArgv, createCliBindings, validateArgs } from "./cli.js";
 import { CLI_OPERATIONS } from "./cli-operations.js";
 import { QuickJsExecutor } from "./executor/quickjs-executor.js";
 import { generateBuiltinTypeDefs } from "./type-generator.js";
@@ -529,6 +529,51 @@ describe("cli command capabilities", () => {
     expect(() => buildCliArgv("ls", "list", { recursive: true })).toThrow(
       "Unknown CLI argument: recursive",
     );
+  });
+
+  test("rejects object and unknown-typed properties instead of silently allowing them", () => {
+    // object-typed property: a non-object value must be rejected (previously silently allowed).
+    expect(() =>
+      validateArgs(
+        {
+          type: "object",
+          properties: { nested: { type: "object" } },
+          additionalProperties: false,
+        },
+        { nested: "not-an-object" },
+      ),
+    ).toThrow("nested must be an object");
+
+    // unknown-typed property (number): a non-conforming value must be rejected.
+    expect(() =>
+      validateArgs(
+        {
+          type: "object",
+          properties: { count: { type: "number" } },
+          additionalProperties: false,
+        },
+        { count: "not-a-number" },
+      ),
+    ).toThrow("count must be a number");
+  });
+
+  test("preserves nested property type errors", () => {
+    expect(() =>
+      validateArgs(
+        {
+          type: "object",
+          properties: {
+            options: {
+              type: "object",
+              properties: { recursive: { type: "boolean" } },
+              additionalProperties: false,
+            },
+          },
+          additionalProperties: false,
+        },
+        { options: { recursive: "yes" } },
+      ),
+    ).toThrow("options must be a boolean");
   });
 
   test("unconfigured operations return clear denial errors", async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,8 @@
 // cli.ts — Typed command capabilities for codemode.
 
 import { spawn } from "node:child_process";
+import Ajv from "ajv";
+import type { JSONSchema7 } from "json-schema";
 import type { CliConfig, CliOperationConfig, CliToolConfig } from "./config.js";
 import { getCliOperationDefinition } from "./cli-operations.js";
 
@@ -240,31 +242,51 @@ function asArgs(args: unknown): Record<string, unknown> {
   return args as Record<string, unknown>;
 }
 
-function validateArgs(
-  schema: { required?: string[]; properties?: Record<string, unknown> },
-  args: Record<string, unknown>,
-): void {
-  const properties = schema.properties ?? {};
-  for (const key of schema.required ?? []) {
-    if (args[key] === undefined) throw new Error(`${key} is required`);
-  }
-  for (const [key, value] of Object.entries(args)) {
-    const prop = properties[key] as { type?: string; enum?: unknown[] } | undefined;
-    if (!prop) throw new Error(`Unknown CLI argument: ${key}`);
-    if (value === undefined) continue;
-    if (prop.enum && !prop.enum.includes(value))
-      throw new Error(`${key} must be one of ${prop.enum.join(", ")}`);
-    if (prop.type === "string" && typeof value !== "string")
-      throw new Error(`${key} must be a string`);
-    if (prop.type === "boolean" && typeof value !== "boolean")
-      throw new Error(`${key} must be a boolean`);
-    if (prop.type === "integer" && (typeof value !== "number" || !Number.isInteger(value)))
-      throw new Error(`${key} must be an integer`);
-    if (
-      prop.type === "array" &&
-      (!Array.isArray(value) || !value.every((v) => typeof v === "string"))
-    )
-      throw new Error(`${key} must be an array of strings`);
+const ajv = new Ajv({ allErrors: false, strict: false });
+
+/** Minimal shape of an Ajv validation error used for message formatting. */
+interface ValidationError {
+  instancePath: string;
+  keyword: string;
+  params: Record<string, unknown>;
+  message?: string;
+}
+
+/**
+ * Validate CLI operation arguments against their JSON-Schema input schema.
+ * Rejects unknown, object, and any other property type that the bespoke
+ * validator previously allowed through silently.
+ */
+export function validateArgs(schema: JSONSchema7, args: Record<string, unknown>): void {
+  const validate = ajv.compile(schema);
+  if (validate(args)) return;
+  const error = validate.errors?.[0] as ValidationError | undefined;
+  throw new Error(error ? formatValidationError(error) : "Invalid CLI arguments");
+}
+
+function formatValidationError(err: ValidationError): string {
+  const key = err.instancePath.split("/").filter(Boolean)[0] ?? "";
+  switch (err.keyword) {
+    case "additionalProperties":
+      return `Unknown CLI argument: ${String(err.params.additionalProperty)}`;
+    case "required":
+      return `${String(err.params.missingProperty)} is required`;
+    case "enum":
+      return `${key} must be one of ${(err.params.allowedValues as unknown[]).join(", ")}`;
+    case "type": {
+      const t = String(err.params.type);
+      const pathSegments = err.instancePath.split("/").filter(Boolean);
+      const isArrayItem = pathSegments.some((segment) => /^\d+$/.test(segment));
+      if (isArrayItem || t === "array") return `${key} must be an array of strings`;
+      if (t === "string") return `${key} must be a string`;
+      if (t === "boolean") return `${key} must be a boolean`;
+      if (t === "integer") return `${key} must be an integer`;
+      if (t === "number") return `${key} must be a number`;
+      if (t === "object") return `${key} must be an object`;
+      return `${key} must be a ${t}`;
+    }
+    default:
+      return `${key} ${err.message ?? "is invalid"}`;
   }
 }
 

--- a/src/execute-tool.ts
+++ b/src/execute-tool.ts
@@ -76,7 +76,7 @@ Available tools in code:
 - File mutation helpers (write, replace_in_file, apply_patch) are intentionally unavailable inside guest code; use the top-level visible patch editing tool instead (patch results render as diffs in chat).
 - codemode.search_tools({ query }) → discover available tools
 - codemode.describe_tools({ namespace, tool? }) → browse MCP tools
-- codemode.<namespace>.<tool>(args) → call MCP tools (e.g., codemode.github.search_issues())
+- mcp.<namespace>.<tool>(args) → call MCP tools (e.g., mcp.github.search_issues())
 - codemode.progress(msg) → stream progress to UI
 - print(...) → optional diagnostic/progress output; avoid printing values you also return
 - π.keyName → string constants from the 'strings' parameter
@@ -87,7 +87,7 @@ Return the final value you want in the result. Prefer return over print for fina
       {
         code: stringSchema({
           description:
-            "TypeScript code body. Has access to read(), codemode.search_tools(), codemode.describe_tools(), codemode.<namespace>.<tool>() for MCP, print(), and π.keyName from strings parameter. File mutation helpers are not available inside guest code; use top-level patch editing instead.",
+            "TypeScript code body. Has access to read(), codemode.search_tools(), codemode.describe_tools(), mcp.<namespace>.<tool>() for MCP, print(), and π.keyName from strings parameter. File mutation helpers are not available inside guest code; use top-level patch editing instead.",
         }),
         strings: recordSchema(stringSchema(), stringSchema(), {
           description:
@@ -421,6 +421,14 @@ async function executeCode(
         name: "codemode",
         fns: bindings as Record<string, (...args: unknown[]) => Promise<unknown>>,
       },
+      ...(bindings.mcp
+        ? [
+            {
+              name: "mcp",
+              fns: bindings.mcp as Record<string, (...args: unknown[]) => Promise<unknown>>,
+            },
+          ]
+        : []),
     ];
 
     const result = await executor.execute(code, providers, {

--- a/src/executor/deno-bootstrap.ts
+++ b/src/executor/deno-bootstrap.ts
@@ -135,6 +135,24 @@ function setupGlobals(userStrings: Record<string, string>): void {
 
   (globalThis as any).read = (args?: unknown) => callTool("read", args);
 
+  (globalThis as any).mcp = new Proxy(
+    {},
+    {
+      get(_, namespace: string) {
+        if (namespace === "then") return undefined;
+        return new Proxy(
+          {},
+          {
+            get(_, tool: string) {
+              if (tool === "then") return undefined;
+              return (args?: unknown) => callTool(`mcp.${namespace}.${tool}`, args);
+            },
+          },
+        );
+      },
+    },
+  );
+
   (globalThis as any).cli = new Proxy(
     {},
     {

--- a/src/executor/quickjs-executor.test.ts
+++ b/src/executor/quickjs-executor.test.ts
@@ -217,13 +217,23 @@ describe("QuickJsExecutor", () => {
 
   test("exposes nested codemode namespaces", async () => {
     const executor = new QuickJsExecutor({ timeout: 5_000 });
+    const result = await executor.execute(`return await mcp.github.search_issues({ q: "test" });`, [
+      { name: "mcp", fns: { github: { search_issues: async (args: unknown) => args } } },
+    ]);
+
+    expect(result.error).toBeUndefined();
+    expect(result.result).toEqual({ q: "test" });
+  });
+
+  test("keeps the legacy codemode MCP namespace working", async () => {
+    const executor = new QuickJsExecutor({ timeout: 5_000 });
     const result = await executor.execute(
-      `return await codemode.github.search_issues({ q: "test" });`,
+      `return await codemode.github.search_issues({ q: "legacy" });`,
       [{ name: "codemode", fns: { github: { search_issues: async (args: unknown) => args } } }],
     );
 
     expect(result.error).toBeUndefined();
-    expect(result.result).toEqual({ q: "test" });
+    expect(result.result).toEqual({ q: "legacy" });
   });
 
   test("does not expose Node globals", async () => {

--- a/src/executor/quickjs-executor.ts
+++ b/src/executor/quickjs-executor.ts
@@ -142,6 +142,17 @@ export class QuickJsExecutor implements CodeExecutor {
 					}
 				});
 				globalThis.read = function(args) { return globalThis.__hostCall('read', args ?? {}); };
+				globalThis.mcp = new Proxy({}, {
+					get(_target, prop) {
+						if (prop === 'then') return undefined;
+						return new Proxy(function(args) { return globalThis.__hostCall('mcp.' + String(prop), args ?? {}); }, {
+							get(_fnTarget, child) {
+								if (child === 'then') return undefined;
+								return function(args) { return globalThis.__hostCall('mcp.' + String(prop) + '.' + String(child), args ?? {}); };
+							}
+						});
+					}
+				});
 				globalThis.cli = new Proxy({}, {
 					get(_target, tool) {
 						if (tool === 'then') return undefined;
@@ -255,6 +266,7 @@ export class QuickJsExecutor implements CodeExecutor {
         globalThis.__hostCall = undefined;
         globalThis.read = undefined;
         globalThis.codemode = undefined;
+        globalThis.mcp = undefined;
         globalThis.cli = undefined;
         globalThis.print = undefined;
         globalThis.console = undefined;

--- a/src/mcp-client.test.ts
+++ b/src/mcp-client.test.ts
@@ -120,7 +120,7 @@ describe("mcp client", () => {
     const client = createMcpClient();
 
     await expect(client.call("github", "search_issues", {})).rejects.toThrow(
-      'Failed to connect MCP server "github-mcp" (codemode.github): should not connect in this test',
+      'Failed to connect MCP server "github-mcp" (mcp.github): should not connect in this test',
     );
   });
 
@@ -129,7 +129,7 @@ describe("mcp client", () => {
     const client = createMcpClient();
 
     await expect(client.call("github", "serch_issues", {})).rejects.toThrow(
-      "Unknown MCP tool: codemode.github.serch_issues(). Available: search_issues, create_issue",
+      "Unknown MCP tool: mcp.github.serch_issues(). Available: search_issues, create_issue",
     );
   });
 
@@ -139,7 +139,7 @@ describe("mcp client", () => {
     const client = createMcpClient();
 
     await expect(client.call("github", "search_issues", {})).rejects.toThrow(
-      'MCP server "github-mcp" (codemode.github) requires authentication. Configure/authenticate it in pi-mcp-adapter first.',
+      'MCP server "github-mcp" (mcp.github) requires authentication. Configure/authenticate it in pi-mcp-adapter first.',
     );
   });
 
@@ -171,7 +171,7 @@ describe("mcp client", () => {
     const client = createMcpClient();
 
     await expect(client.call("github", "serch_issues", {})).rejects.toThrow(
-      "Unknown MCP tool: codemode.github.serch_issues(). Available: search_issues, create_issue",
+      "Unknown MCP tool: mcp.github.serch_issues(). Available: search_issues, create_issue",
     );
   });
 

--- a/src/mcp-client.ts
+++ b/src/mcp-client.ts
@@ -117,13 +117,13 @@ export function createMcpClient(options?: McpClientOptions): McpClient {
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       throw new Error(
-        `Failed to connect MCP server "${serverName}" (codemode.${namespace}): ${message}`,
+        `Failed to connect MCP server "${serverName}" (mcp.${namespace}): ${message}`,
       );
     }
 
     if (connection.status === "needs-auth") {
       throw new Error(
-        `MCP server "${serverName}" (codemode.${namespace}) requires authentication. Configure/authenticate it in pi-mcp-adapter first.`,
+        `MCP server "${serverName}" (mcp.${namespace}) requires authentication. Configure/authenticate it in pi-mcp-adapter first.`,
       );
     }
 
@@ -174,7 +174,7 @@ export function createMcpClient(options?: McpClientOptions): McpClient {
       if (info.tools.length > 0 && !resolvedToolName) {
         const available = info.tools.map((t) => t.name).join(", ");
         throw new Error(
-          `Unknown MCP tool: codemode.${namespace}.${toolName}(). Available: ${available}`,
+          `Unknown MCP tool: mcp.${namespace}.${toolName}(). Available: ${available}`,
         );
       }
       const mcpToolName = resolvedToolName ?? toolName;
@@ -203,7 +203,7 @@ export function createMcpClient(options?: McpClientOptions): McpClient {
 
         if (result.isError) {
           const toolInfo = info.tools.find((t) => t.name === mcpToolName);
-          let errorMsg = `MCP tool error: codemode.${namespace}.${toolName}()\n\n${text}`;
+          let errorMsg = `MCP tool error: mcp.${namespace}.${toolName}()\n\n${text}`;
           if (toolInfo?.inputSchema) {
             if (enrichError) {
               errorMsg += `\n\n${enrichError(toolInfo.inputSchema)}`;

--- a/src/search.test.ts
+++ b/src/search.test.ts
@@ -67,7 +67,7 @@ describe("tool search", () => {
       ],
     );
 
-    expect(searchTools("owner")).toContain("[github] codemode.github.search_issues()");
+    expect(searchTools("owner")).toContain("[github] mcp.github.search_issues()");
     expect(searchTools("repo")).toContain("Find matching issues");
   });
 
@@ -107,7 +107,7 @@ describe("tool search", () => {
       ],
     );
 
-    expect(searchTools("githb")).toContain("codemode.github.search_issues()");
+    expect(searchTools("githb")).toContain("mcp.github.search_issues()");
   });
 
   test("surfaces editing guidance for replace, patch, write, and diff queries", () => {

--- a/src/search.ts
+++ b/src/search.ts
@@ -17,7 +17,7 @@ export interface SearchDoc {
   description: string;
   /** "pi" or MCP server namespace */
   source: string;
-  /** How to call it: "read({ path })" or "codemode.github.search_issues({ ... })" */
+  /** How to call it: "read({ path })" or "mcp.github.search_issues({ ... })" */
   callSig: string;
   /** Parameter names joined (for matching on param names) */
   params: string;
@@ -114,7 +114,7 @@ export function buildSearchIndex(
           name: tool.name,
           description: tool.description ?? "",
           source: server.namespace,
-          callSig: `codemode.${server.namespace}.${tool.name}()`,
+          callSig: `mcp.${server.namespace}.${tool.name}()`,
           params: paramNames.join(" "),
         });
       }

--- a/src/system-prompt.ts
+++ b/src/system-prompt.ts
@@ -25,6 +25,13 @@ individually, write TypeScript code that calls multiple tools and returns just w
 Your code is **type-checked** against the tool API before execution. Type errors are
 returned for correction — no side effects occur until types are valid.
 
+### Namespace Map
+
+- \`codemode.*\` — Codemode built-ins such as discovery and npm helpers.
+- \`mcp.<namespace>.<tool>(...)\` — configured MCP server tools.
+- \`cli.<command>.<operation>(...)\` — configured host CLI wrappers.
+- \`codemode.<namespace>.<tool>(...)\` is retained only as a legacy MCP alias.
+
 ### Built-in Tool API
 
 \`\`\`typescript
@@ -33,7 +40,7 @@ ${builtinTypeDefs}
 ${mcpSummary ? "\n" + mcpSummary + "\n" : ""}
 ### How to use
 
-Call the top-level \`codemode\` tool with a TypeScript code body. Use top-level \`read\` for file inspection; file mutation helpers are intentionally unavailable inside guest code. Use top-level visible patch editing instead (patch results render as diffs in chat). Use the in-guest \`codemode.*\` object for discovery and MCP tools. Prefer \`return\` for the final value. Use \`print()\` only for diagnostics or intermediate output you do not also return.
+Call the top-level \`codemode\` tool with a TypeScript code body. Use top-level \`read\` for file inspection; file mutation helpers are intentionally unavailable inside guest code. Use top-level visible patch editing instead (patch results render as diffs in chat). Use \`codemode.*\` for built-in discovery helpers and \`mcp.*\` for MCP tools. Prefer \`return\` for the final value. Use \`print()\` only for diagnostics or intermediate output you do not also return.
 
 Write human-readable, nicely formatted TypeScript with normal line breaks in codemode calls. Avoid cramming multiple statements into one long line; the code is shown in the transcript while it runs and should be easy for the user to review.
 
@@ -121,7 +128,7 @@ const details = await codemode.describe_tools({
 print(details);
 
 // Step 3: Call with the correct parameters
-const issues = await codemode.github.search_issues({ query: "is:open label:bug" });
+const issues = await mcp.github.search_issues({ query: "is:open label:bug" });
 return issues;
 \`\`\`
 

--- a/src/tool-bindings.test.ts
+++ b/src/tool-bindings.test.ts
@@ -2,7 +2,7 @@ import { execFileSync } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import { createToolBindings } from "./tool-bindings.js";
 import type { McpServerInfo } from "./search.js";
 
@@ -120,12 +120,42 @@ describe("createToolBindings MCP discovery", () => {
     ).resolves.toContain("unified diff");
   });
 
+  test("calls MCP tools through the preferred mcp namespace", async () => {
+    const call = vi.fn<() => Promise<string>>(async () => "ok");
+    const bindings = createToolBindings({
+      cwd: process.cwd(),
+      mcpServers,
+      mcpClient: {
+        available: true,
+        getServers: () => mcpServers,
+        listServers: () => ["github-mcp", "slack"],
+        warmCache: async () => mcpServers,
+        ensureServerConnected: async () => mcpServers[0],
+        call,
+        shutdown: async () => undefined,
+      },
+    });
+
+    await expect(
+      (bindings.mcp as Record<string, Record<string, unknown>>).github.search_issues,
+    ).toBeDefined();
+    await expect(
+      (
+        (bindings.mcp as Record<string, Record<string, (args: unknown) => Promise<string>>>).github
+          .search_issues as (args: unknown) => Promise<string>
+      )({ query: "test" }),
+    ).resolves.toBe("ok");
+    expect(call).toHaveBeenCalledWith("github", "search_issues", { query: "test" });
+  });
+
   test("lists MCP servers without exposing them as top-level tools", async () => {
     const bindings = createToolBindings({ cwd: process.cwd(), mcpServers });
 
     await expect(bindings.list_mcp_servers()).resolves.toContain(
-      "codemode.github — github-mcp (2 cached tools)",
+      "mcp.github — github-mcp (2 cached tools)",
     );
+    expect(typeof bindings.mcp).toBe("object");
+    expect(typeof (bindings.mcp as Record<string, unknown>).github).toBe("object");
     expect(typeof bindings.github).toBe("object");
     expect(bindings.search_issues).toBeUndefined();
   });
@@ -174,7 +204,7 @@ describe("createToolBindings MCP discovery", () => {
 
     await expect(
       bindings.list_tools({ namespace: "github", offset: 1, limit: 1 }),
-    ).resolves.toContain("codemode.github tools 2-2 of 2");
+    ).resolves.toContain("mcp.github tools 2-2 of 2");
     await expect(
       bindings.list_tools({ namespace: "github", offset: 1, limit: 1 }),
     ).resolves.toContain("create_issue(args?: Record<string, unknown>) — Create an issue");

--- a/src/tool-bindings.ts
+++ b/src/tool-bindings.ts
@@ -1,7 +1,7 @@
 // tool-bindings.ts — Create runtime bindings that back the TypeScript type declarations.
 //
 // Each binding wraps a real Pi tool implementation and returns simplified values.
-// MCP tools are exposed as nested namespaces (e.g., codemode.github.search_issues).
+// MCP tools are exposed as nested namespaces (e.g., mcp.github.search_issues).
 
 import type { AgentToolUpdateCallback } from "@mariozechner/pi-agent-core";
 import { readFileSync } from "node:fs";
@@ -31,6 +31,7 @@ export interface ToolBindings {
   plan_npm_script(params: { script: string }): Promise<string>;
   run_npm_script(params: { script: string; verbose?: boolean }): Promise<string>;
   cli: Record<string, unknown>;
+  mcp?: Record<string, unknown>;
   progress(message: string): void;
   /** MCP server namespaces are added dynamically */
   [serverNamespace: string]: unknown;
@@ -144,7 +145,7 @@ export function createToolBindings(options: ToolBindingsOptions): ToolBindings {
       return mcpServers
         .map(
           (server) =>
-            `codemode.${server.namespace} — ${server.serverName} (${server.tools.length} cached tools)`,
+            `mcp.${server.namespace} — ${server.serverName} (${server.tools.length} cached tools)`,
         )
         .join("\n");
     },
@@ -183,7 +184,7 @@ export function createToolBindings(options: ToolBindingsOptions): ToolBindings {
       if (!params.tool) {
         // List all tools in this namespace
         if (server.tools.length === 0) {
-          return `codemode.${server.namespace} has no cached tools. Call any tool to trigger a connection.`;
+          return `mcp.${server.namespace} has no cached tools. Call any tool to trigger a connection.`;
         }
         return listServerTools(server, 0, 50);
       }
@@ -192,7 +193,7 @@ export function createToolBindings(options: ToolBindingsOptions): ToolBindings {
       const tool = server.tools.find((t) => t.name === params.tool);
       if (!tool) {
         const names = server.tools.map((t) => t.name).join(", ");
-        return `Unknown tool "${params.tool}" in codemode.${server.namespace}. Available: ${names}`;
+        return `Unknown tool "${params.tool}" in mcp.${server.namespace}. Available: ${names}`;
       }
 
       return generateToolSignature(server.namespace, tool.name, tool.description, tool.inputSchema);
@@ -215,9 +216,10 @@ export function createToolBindings(options: ToolBindingsOptions): ToolBindings {
     return mcpClient.ensureServerConnected(namespace);
   }
 
-  // Add per-server MCP namespaces as proxies
-  // These will be callable as codemode.<namespace>.<tool>(args)
+  // Add per-server MCP namespaces as proxies. `mcp` is the preferred root;
+  // the direct namespace remains as a compatibility alias for older callers.
   if (mcpServers) {
+    const mcpBindings: Record<string, unknown> = {};
     for (const server of mcpServers) {
       const serverProxy: Record<string, (args?: Record<string, unknown>) => Promise<string>> = {};
 
@@ -230,7 +232,7 @@ export function createToolBindings(options: ToolBindingsOptions): ToolBindings {
       }
 
       // Add a Proxy fallback for uncached tools
-      bindings[server.namespace] = new Proxy(serverProxy, {
+      const proxy = new Proxy(serverProxy, {
         get(target, prop: string) {
           if (prop in target) return target[prop];
           // Return a function that will attempt the call (lazy connect)
@@ -241,7 +243,10 @@ export function createToolBindings(options: ToolBindingsOptions): ToolBindings {
           };
         },
       });
+      mcpBindings[server.namespace] = proxy;
+      bindings[server.namespace] = proxy;
     }
+    bindings.mcp = mcpBindings;
   }
 
   return bindings;
@@ -280,7 +285,7 @@ function simpleSchemaType(schema: Record<string, unknown>): string {
 
 function listServerTools(server: McpServerInfo, offset = 0, limit = 50): string {
   if (server.tools.length === 0) {
-    return `codemode.${server.namespace} has no cached tools. Call any tool to trigger a connection.`;
+    return `mcp.${server.namespace} has no cached tools. Call any tool to trigger a connection.`;
   }
 
   const safeOffset = Math.max(0, offset);
@@ -288,7 +293,7 @@ function listServerTools(server: McpServerInfo, offset = 0, limit = 50): string 
   const visible = server.tools.slice(safeOffset, safeOffset + safeLimit);
   const start = visible.length > 0 ? safeOffset + 1 : 0;
   const end = safeOffset + visible.length;
-  let text = `codemode.${server.namespace} tools ${start}-${end} of ${server.tools.length}`;
+  let text = `mcp.${server.namespace} tools ${start}-${end} of ${server.tools.length}`;
   if (visible.length < server.tools.length) {
     text += ` (showing ${visible.length} of ${server.tools.length} tools)`;
   }
@@ -354,7 +359,7 @@ function describeBuiltinTools(toolName?: string): string {
       params: "{ script: string; verbose?: boolean }",
     },
     list_mcp_servers: {
-      description: "List configured MCP server namespaces available under codemode.*.",
+      description: "List configured MCP server namespaces available under mcp.*.",
       params: "{}",
     },
     list_tools: {

--- a/src/type-generator.test.ts
+++ b/src/type-generator.test.ts
@@ -60,6 +60,21 @@ describe("built-in file tool type definitions", () => {
 });
 
 describe("MCP server type definitions", () => {
+  test("exposes MCP servers under the mcp namespace", () => {
+    const typeDefs =
+      generateBuiltinTypeDefs() +
+      generateMcpServerTypeDefs([
+        {
+          serverName: "GitHub",
+          namespace: "github",
+          tools: [{ name: "search_issues", inputSchema: { type: "object" } }],
+        },
+      ]);
+
+    expect(typeDefs).toContain("declare const mcp: McpServerNamespaces;");
+    expect(typeCheck("await mcp.github.search_issues({});", typeDefs).errors).toEqual([]);
+  });
+
   test("sanitizes tool and namespace names and maps JSON schema properties", () => {
     const typeDefs = generateMcpServerTypeDefs([
       {

--- a/src/type-generator.ts
+++ b/src/type-generator.ts
@@ -153,7 +153,7 @@ const builtinToolDescriptors: Record<string, { description?: string; inputSchema
     },
   },
   list_mcp_servers: {
-    description: "List configured MCP server namespaces available under codemode.*.",
+    description: "List configured MCP server namespaces available under mcp.*.",
     inputSchema: {
       type: "object",
       properties: {},
@@ -324,7 +324,14 @@ export function generateBuiltinTypeDefs(config?: { cli?: CliConfig }): string {
 declare function read(args: { path: string; offset?: number; limit?: number }): Promise<string>;
 /** File mutation is intentionally not available inside codemode guest code. Use the top-level visible patch editing tool instead; patch results render as diffs in chat. */
 
+/**
+ * Codemode built-ins and MCP server tools.
+ * @deprecated Use \`mcp.<namespace>.<tool>()\` for MCP tools.
+ */
 declare const codemode: CodemodeTools & McpServerNamespaces;
+
+/** MCP server tools discovered for this session. */
+declare const mcp: McpServerNamespaces;
 
 interface McpServerNamespaces {}
 
@@ -364,6 +371,7 @@ interface McpServerNamespaces {}
   const parts: string[] = [];
 
   // Generate the McpServerNamespaces interface
+  parts.push(`/** MCP server tools discovered for this session. */`);
   parts.push(`interface McpServerNamespaces {`);
   for (const server of servers) {
     parts.push(`  /** MCP server: ${server.serverName} (${server.tools.length} tools) */`);
@@ -429,7 +437,7 @@ export function generateMcpSummaryForPrompt(servers: McpServerInfo[]): string {
   const lines: string[] = [];
   lines.push(`### MCP Servers`);
   lines.push(``);
-  lines.push(`The following MCP servers are available as typed namespaces on \`codemode\`.`);
+  lines.push(`The following MCP servers are available as typed namespaces on \`mcp\`.`);
   lines.push(
     `Use \`codemode.describe_tools({ namespace: "..." })\` to browse tools and see their parameters.`,
   );
@@ -440,11 +448,11 @@ export function generateMcpSummaryForPrompt(servers: McpServerInfo[]): string {
     const count = server.tools.length;
     if (count === 0) {
       lines.push(
-        `- **codemode.${sanitizeIdentifier(server.namespace)}** — ${server.serverName} (connect on first call)`,
+        `- **mcp.${sanitizeIdentifier(server.namespace)}** — ${server.serverName} (connect on first call)`,
       );
     } else {
       lines.push(
-        `- **codemode.${sanitizeIdentifier(server.namespace)}** — ${server.serverName} (${count} tools)`,
+        `- **mcp.${sanitizeIdentifier(server.namespace)}** — ${server.serverName} (${count} tools)`,
       );
     }
   }
@@ -481,7 +489,7 @@ export function generateToolSignature(
       .map((line) => line.trim())
       .find((line) => line.includes("(args")) || `${sanitizeToolName(toolName)}(args: any)`;
 
-  lines.push(`codemode.${namespace}.${sig}: Promise<string>`);
+  lines.push(`mcp.${namespace}.${sig}: Promise<string>`);
   return lines.join("\n");
 }
 

--- a/src/types/ajv.d.ts
+++ b/src/types/ajv.d.ts
@@ -1,0 +1,20 @@
+declare module "ajv" {
+  interface AjvOptions {
+    allErrors?: boolean;
+    strict?: boolean | "log";
+  }
+  interface ValidationError {
+    instancePath: string;
+    keyword: string;
+    params: Record<string, unknown>;
+    message?: string;
+  }
+  interface ValidateFunction {
+    (data: unknown): boolean;
+    errors?: ValidationError[] | null;
+  }
+  export default class Ajv {
+    constructor(options?: AjvOptions);
+    compile(schema: unknown): ValidateFunction;
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,15 @@
     "noUnusedParameters": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "typeRoots": ["./src/types", "./node_modules/@types"]
+    "typeRoots": ["./src/types", "./node_modules/@types"],
+    "paths": {
+      "pi-mcp-adapter/types.js": ["./src/adapter-shims/types.d.ts"],
+      "pi-mcp-adapter/server-manager.js": ["./src/adapter-shims/server-manager.d.ts"],
+      "pi-mcp-adapter/config.js": ["./src/adapter-shims/config.d.ts"],
+      "pi-mcp-adapter/metadata-cache.js": ["./src/adapter-shims/metadata-cache.d.ts"],
+      "pi-mcp-adapter/tool-registrar.js": ["./src/adapter-shims/tool-registrar.d.ts"]
+    },
+    "types": ["node"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary

- expose configured MCP tools under the preferred `mcp.<namespace>.<tool>()` API
- retain `codemode.<namespace>.<tool>()` as a compatibility alias
- update QuickJS/Deno runtime providers, generated declarations, discovery, search, errors, prompts, docs, and tests

Closes #55

## Verification

- `npm run check`