### PR TITLE
fix(security): fence guest CLI operands

### DIFF
--- a/src/cli-operations.ts
+++ b/src/cli-operations.ts
@@ -167,7 +167,7 @@ export const CLI_OPERATIONS: Record<string, Record<string, CliOperationDefinitio
         ...(args.staged ? ["--cached"] : []),
         ...(args.stat ? ["--stat"] : []),
         ...(args.nameOnly ? ["--name-only"] : []),
-        ...optionalString(args.ref, "ref"),
+        ...optionalOperand(args.ref, "ref"),
         ...pathspec(args.paths),
       ],
     },
@@ -204,7 +204,7 @@ export const CLI_OPERATIONS: Record<string, Record<string, CliOperationDefinitio
         "show",
         ...(args.stat ? ["--stat"] : []),
         ...(args.nameOnly ? ["--name-only"] : []),
-        ...optionalString(args.ref, "ref"),
+        ...optionalOperand(args.ref, "ref"),
       ],
     },
     remote: {
@@ -229,7 +229,7 @@ export const CLI_OPERATIONS: Record<string, Record<string, CliOperationDefinitio
         "rev-parse",
         ...(args.showTopLevel ? ["--show-toplevel"] : []),
         ...(args.isInsideWorkTree ? ["--is-inside-work-tree"] : []),
-        ...optionalString(args.ref, "ref"),
+        ...optionalOperand(args.ref, "ref"),
       ],
     },
     add: {
@@ -285,8 +285,10 @@ export const CLI_OPERATIONS: Record<string, Record<string, CliOperationDefinitio
         "push",
         ...(args.setUpstream ? ["--set-upstream"] : []),
         ...(args.tags ? ["--tags"] : []),
-        ...optionalString(args.remote, "remote"),
-        ...optionalString(args.branch, "branch"),
+        ...positionalsWithDelimiter([
+          [args.remote, "remote"],
+          [args.branch, "branch"],
+        ]),
       ],
     },
     pull: {
@@ -304,8 +306,10 @@ export const CLI_OPERATIONS: Record<string, Record<string, CliOperationDefinitio
         "pull",
         ...(args.rebase ? ["--rebase"] : []),
         ...(args.ffOnly ? ["--ff-only"] : []),
-        ...optionalString(args.remote, "remote"),
-        ...optionalString(args.branch, "branch"),
+        ...positionalsWithDelimiter([
+          [args.remote, "remote"],
+          [args.branch, "branch"],
+        ]),
       ],
     },
     switch: {
@@ -325,7 +329,7 @@ export const CLI_OPERATIONS: Record<string, Record<string, CliOperationDefinitio
         "switch",
         ...(args.create ? ["--create"] : []),
         ...(args.detach ? ["--detach"] : []),
-        requiredString(args, "branch"),
+        safeOperand(requiredString(args, "branch"), "branch"),
       ],
     },
     checkout: {
@@ -336,7 +340,7 @@ export const CLI_OPERATIONS: Record<string, Record<string, CliOperationDefinitio
       inputSchema: obj({ branch: s("Branch or tree-ish."), paths: sa("Paths to check out.") }),
       toArgv: (args) => [
         "checkout",
-        ...optionalString(args.branch, "branch"),
+        ...optionalOperand(args.branch, "branch"),
         ...pathspec(args.paths),
       ],
     },
@@ -353,7 +357,7 @@ export const CLI_OPERATIONS: Record<string, Record<string, CliOperationDefinitio
       toArgv: (args) => [
         "restore",
         ...(args.staged ? ["--staged"] : []),
-        ...stringFlag("--source", args.source, "source"),
+        ...stringEqualsFlag("--source", args.source, "source"),
         ...pathspec(args.paths),
       ],
     },
@@ -370,7 +374,7 @@ export const CLI_OPERATIONS: Record<string, Record<string, CliOperationDefinitio
       toArgv: (args) => [
         "reset",
         ...resetMode(args.mode),
-        ...optionalString(args.ref, "ref"),
+        ...optionalOperand(args.ref, "ref"),
         ...pathspec(args.paths),
       ],
     },
@@ -390,7 +394,7 @@ export const CLI_OPERATIONS: Record<string, Record<string, CliOperationDefinitio
         ...stashCommand(args.command),
         ...(args.includeUntracked ? ["--include-untracked"] : []),
         ...stringFlag("-m", args.message, "message"),
-        ...optionalString(args.stash, "stash"),
+        ...optionalOperand(args.stash, "stash"),
       ],
     },
     tag: {
@@ -409,7 +413,7 @@ export const CLI_OPERATIONS: Record<string, Record<string, CliOperationDefinitio
         ...(args.delete ? ["--delete"] : []),
         ...(args.list ? ["--list"] : []),
         ...(args.message ? ["-a"] : []),
-        ...optionalString(args.name, "name"),
+        ...optionalOperand(args.name, "name"),
         ...stringFlag("-m", args.message, "message"),
       ],
     },
@@ -797,9 +801,10 @@ export const CLI_OPERATIONS: Record<string, Record<string, CliOperationDefinitio
         ...(args.lineNumber ? ["--line-number"] : []),
         ...(args.hidden ? ["--hidden"] : []),
         ...numberFlag("--max-count", args.maxCount),
-        ...stringArrayFlag("--glob", args.glob),
+        ...stringEqualsArrayFlag("--glob", args.glob, "glob"),
+        "-e",
         requiredString(args, "pattern"),
-        ...stringArray(args.paths),
+        ...pathspec(args.paths),
       ],
     },
   },
@@ -816,9 +821,10 @@ export const CLI_OPERATIONS: Record<string, Record<string, CliOperationDefinitio
         type: findTypeSchema,
       }),
       toArgv: (args) => [
-        stringArg(args.path, "."),
+        "--",
+        safeStringArg(args.path, ".", "path"),
         ...numberFlag("-maxdepth", args.maxDepth),
-        ...(args.name === undefined ? [] : ["-name", stringArg(args.name, "", "name")]),
+        ...(args.name === undefined ? [] : ["-name", safeOperand(args.name, "name")]),
         ...findType(args.type),
       ],
     },
@@ -841,8 +847,9 @@ export const CLI_OPERATIONS: Record<string, Record<string, CliOperationDefinitio
       toArgv: (args) => [
         ...(args.recursive ? ["-R"] : []),
         ...(args.ignoreCase ? ["-i"] : []),
+        "-e",
         requiredString(args, "pattern"),
-        ...stringArray(args.paths),
+        ...pathspec(args.paths),
       ],
     },
   },
@@ -860,7 +867,7 @@ export const CLI_OPERATIONS: Record<string, Record<string, CliOperationDefinitio
       toArgv: (args) => [
         ...(args.all ? ["-a"] : []),
         ...(args.long ? ["-l"] : []),
-        ...(args.path === undefined ? [] : [stringArg(args.path, ".")]),
+        ...(args.path === undefined ? [] : ["--", safeStringArg(args.path, ".", "path")]),
       ],
     },
   },
@@ -877,9 +884,9 @@ export const CLI_OPERATIONS: Record<string, Record<string, CliOperationDefinitio
       }),
       toArgv: (args) => [
         "run",
-        ...stringArray(args.paths),
         ...(args.update ? ["--update"] : []),
         ...reporter(args.reporter),
+        ...pathspec(args.paths),
       ],
     },
   },
@@ -900,7 +907,7 @@ export const CLI_OPERATIONS: Record<string, Record<string, CliOperationDefinitio
       docs: "Check formatting with oxfmt without writing changes.",
       params: ["paths"],
       inputSchema: obj({ paths: sa("Paths to check.") }),
-      toArgv: (args) => [...stringArray(args.paths), "--check"],
+      toArgv: (args) => ["--check", ...pathspec(args.paths)],
     },
     write: {
       effect: "write",
@@ -908,7 +915,7 @@ export const CLI_OPERATIONS: Record<string, Record<string, CliOperationDefinitio
       docs: "Format files in place with oxfmt.",
       params: ["paths"],
       inputSchema: obj({ paths: sa("Paths to format.") }),
-      toArgv: (args) => [...stringArray(args.paths), "--write"],
+      toArgv: (args) => ["--write", ...pathspec(args.paths)],
     },
   },
   oxlint: {
@@ -925,7 +932,7 @@ export const CLI_OPERATIONS: Record<string, Record<string, CliOperationDefinitio
       toArgv: (args) => [
         ...stringFlag("--deny", args.deny, "deny"),
         ...(args.vitestPlugin ? ["--vitest-plugin"] : []),
-        ...stringArray(args.paths),
+        ...pathspec(args.paths),
       ],
     },
   },
@@ -949,10 +956,8 @@ function requiredNumber(args: Record<string, unknown>, key: string): string {
     throw new Error(`${key} must be an integer`);
   return String(value);
 }
-function stringArg(value: unknown, fallback: string, key = "path"): string {
-  if (value === undefined) return fallback;
-  if (typeof value !== "string") throw new Error(`${key} must be a string`);
-  return value;
+function safeStringArg(value: unknown, fallback: string, key: string): string {
+  return safeOperand(value === undefined ? fallback : value, key);
 }
 function stringArray(value: unknown, key = "paths"): string[] {
   if (value === undefined) return [];
@@ -969,10 +974,33 @@ function numberFlag(flag: string, value: unknown): string[] {
 function stringArrayFlag(flag: string, value: unknown): string[] {
   return stringArray(value, flag).flatMap((v) => [flag, v]);
 }
-function optionalString(value: unknown, key: string): string[] {
+function optionalOperand(value: unknown, key: string): string[] {
   if (value === undefined) return [];
-  if (typeof value !== "string") throw new Error(`${key} must be a string`);
-  return [value];
+  return [safeOperand(value, key)];
+}
+function positionalsWithDelimiter(values: Array<[unknown, string]>): string[] {
+  const operands = values.flatMap(([value, key]) => optionalOperand(value, key));
+  return operands.length === 0 ? [] : ["--", ...operands];
+}
+function safeOperand(value: unknown, key: string): string {
+  if (typeof value !== "string" || value.length === 0 || value.startsWith("-")) {
+    throw new Error(`${key} must not be empty or start with '-'`);
+  }
+  return value;
+}
+function stringEqualsFlag(flag: string, value: unknown, key: string): string[] {
+  if (value === undefined) return [];
+  return [`${flag}=${safeOperand(value, key)}`];
+}
+function stringEqualsArrayFlag(flag: string, value: unknown, key: string): string[] {
+  if (value === undefined) return [];
+  return stringArray(value, key).map((v) => `${flag}=${nonEmptyString(v, key)}`);
+}
+function nonEmptyString(value: unknown, key: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`${key} must not be empty`);
+  }
+  return value;
 }
 function stringFlag(flag: string, value: unknown, key: string): string[] {
   if (value === undefined) return [];
@@ -991,8 +1019,15 @@ function stashCommand(value: unknown): string[] {
   throw new Error("command must be one of push, pop, apply, list, drop, clear");
 }
 function pathspec(value: unknown): string[] {
-  const paths = stringArray(value);
+  const paths = safeOperandArray(value);
   return paths.length === 0 ? [] : ["--", ...paths];
+}
+function safeOperandArray(value: unknown, key = "paths"): string[] {
+  const values = stringArray(value, key);
+  if (values.some((v) => v.length === 0 || v.startsWith("-"))) {
+    throw new Error(`${key} must not contain empty operands or operands starting with '-'`);
+  }
+  return values;
 }
 function repo(args: Record<string, unknown>): string[] {
   if (args.repo === undefined) return [];

--- a/src/cli-operations.ts
+++ b/src/cli-operations.ts
@@ -167,7 +167,7 @@ export const CLI_OPERATIONS: Record<string, Record<string, CliOperationDefinitio
         ...(args.staged ? ["--cached"] : []),
         ...(args.stat ? ["--stat"] : []),
         ...(args.nameOnly ? ["--name-only"] : []),
-        ...optionalOperand(args.ref, "ref"),
+        ...positionalsWithDelimiter([[args.ref, "ref"]]),
         ...pathspec(args.paths),
       ],
     },
@@ -204,7 +204,7 @@ export const CLI_OPERATIONS: Record<string, Record<string, CliOperationDefinitio
         "show",
         ...(args.stat ? ["--stat"] : []),
         ...(args.nameOnly ? ["--name-only"] : []),
-        ...optionalOperand(args.ref, "ref"),
+        ...positionalsWithDelimiter([[args.ref, "ref"]]),
       ],
     },
     remote: {
@@ -229,7 +229,7 @@ export const CLI_OPERATIONS: Record<string, Record<string, CliOperationDefinitio
         "rev-parse",
         ...(args.showTopLevel ? ["--show-toplevel"] : []),
         ...(args.isInsideWorkTree ? ["--is-inside-work-tree"] : []),
-        ...optionalOperand(args.ref, "ref"),
+        ...positionalsWithDelimiter([[args.ref, "ref"]]),
       ],
     },
     add: {
@@ -266,8 +266,7 @@ export const CLI_OPERATIONS: Record<string, Record<string, CliOperationDefinitio
         "commit",
         ...(args.all ? ["--all"] : []),
         ...(args.amend ? ["--amend"] : []),
-        "-m",
-        requiredString(args, "message"),
+        ...stringFlag("--message", requiredString(args, "message"), "message"),
       ],
     },
     push: {
@@ -329,7 +328,7 @@ export const CLI_OPERATIONS: Record<string, Record<string, CliOperationDefinitio
         "switch",
         ...(args.create ? ["--create"] : []),
         ...(args.detach ? ["--detach"] : []),
-        safeOperand(requiredString(args, "branch"), "branch"),
+        ...positionalsWithDelimiter([[requiredString(args, "branch"), "branch"]]),
       ],
     },
     checkout: {
@@ -340,7 +339,7 @@ export const CLI_OPERATIONS: Record<string, Record<string, CliOperationDefinitio
       inputSchema: obj({ branch: s("Branch or tree-ish."), paths: sa("Paths to check out.") }),
       toArgv: (args) => [
         "checkout",
-        ...optionalOperand(args.branch, "branch"),
+        ...positionalsWithDelimiter([[args.branch, "branch"]]),
         ...pathspec(args.paths),
       ],
     },
@@ -374,7 +373,7 @@ export const CLI_OPERATIONS: Record<string, Record<string, CliOperationDefinitio
       toArgv: (args) => [
         "reset",
         ...resetMode(args.mode),
-        ...optionalOperand(args.ref, "ref"),
+        ...positionalsWithDelimiter([[args.ref, "ref"]]),
         ...pathspec(args.paths),
       ],
     },
@@ -393,7 +392,7 @@ export const CLI_OPERATIONS: Record<string, Record<string, CliOperationDefinitio
         "stash",
         ...stashCommand(args.command),
         ...(args.includeUntracked ? ["--include-untracked"] : []),
-        ...stringFlag("-m", args.message, "message"),
+        ...stringFlag("--message", args.message, "message"),
         ...optionalOperand(args.stash, "stash"),
       ],
     },
@@ -413,8 +412,8 @@ export const CLI_OPERATIONS: Record<string, Record<string, CliOperationDefinitio
         ...(args.delete ? ["--delete"] : []),
         ...(args.list ? ["--list"] : []),
         ...(args.message ? ["-a"] : []),
-        ...optionalOperand(args.name, "name"),
-        ...stringFlag("-m", args.message, "message"),
+        ...stringFlag("--message", args.message, "message"),
+        ...positionalsWithDelimiter([[args.name, "name"]]),
       ],
     },
   },
@@ -478,8 +477,7 @@ export const CLI_OPERATIONS: Record<string, Record<string, CliOperationDefinitio
       toArgv: (args) => [
         "issue",
         "create",
-        "--title",
-        requiredString(args, "title"),
+        ...stringFlag("--title", requiredString(args, "title"), "title"),
         ...stringFlag("--body", args.body, "body"),
         ...stringArrayFlag("--label", args.label),
         ...stringArrayFlag("--assignee", args.assignee),
@@ -545,8 +543,7 @@ export const CLI_OPERATIONS: Record<string, Record<string, CliOperationDefinitio
         "issue",
         "comment",
         requiredNumber(args, "number"),
-        "--body",
-        requiredString(args, "body"),
+        ...stringFlag("--body", requiredString(args, "body"), "body"),
         ...repo(args),
       ],
     },
@@ -972,7 +969,7 @@ function numberFlag(flag: string, value: unknown): string[] {
   return [flag, String(value)];
 }
 function stringArrayFlag(flag: string, value: unknown): string[] {
-  return stringArray(value, flag).flatMap((v) => [flag, v]);
+  return stringArray(value, flag).map((v) => `${flag}=${v}`);
 }
 function optionalOperand(value: unknown, key: string): string[] {
   if (value === undefined) return [];
@@ -1005,7 +1002,7 @@ function nonEmptyString(value: unknown, key: string): string {
 function stringFlag(flag: string, value: unknown, key: string): string[] {
   if (value === undefined) return [];
   if (typeof value !== "string") throw new Error(`${key} must be a string`);
-  return [flag, value];
+  return [`${flag}=${value}`];
 }
 function resetMode(value: unknown): string[] {
   if (value === undefined) return [];
@@ -1030,9 +1027,7 @@ function safeOperandArray(value: unknown, key = "paths"): string[] {
   return values;
 }
 function repo(args: Record<string, unknown>): string[] {
-  if (args.repo === undefined) return [];
-  if (typeof args.repo !== "string") throw new Error("repo must be a string");
-  return ["--repo", args.repo];
+  return stringFlag("--repo", args.repo, "repo");
 }
 function repoApiPath(value: unknown): string {
   if (value === undefined) return "repos/{owner}/{repo}";

--- a/src/cli-operations.ts
+++ b/src/cli-operations.ts
@@ -167,7 +167,7 @@ export const CLI_OPERATIONS: Record<string, Record<string, CliOperationDefinitio
         ...(args.staged ? ["--cached"] : []),
         ...(args.stat ? ["--stat"] : []),
         ...(args.nameOnly ? ["--name-only"] : []),
-        ...positionalsWithDelimiter([[args.ref, "ref"]]),
+        ...optionalOperand(args.ref, "ref"),
         ...pathspec(args.paths),
       ],
     },
@@ -204,7 +204,7 @@ export const CLI_OPERATIONS: Record<string, Record<string, CliOperationDefinitio
         "show",
         ...(args.stat ? ["--stat"] : []),
         ...(args.nameOnly ? ["--name-only"] : []),
-        ...positionalsWithDelimiter([[args.ref, "ref"]]),
+        ...optionalOperand(args.ref, "ref"),
       ],
     },
     remote: {
@@ -229,7 +229,7 @@ export const CLI_OPERATIONS: Record<string, Record<string, CliOperationDefinitio
         "rev-parse",
         ...(args.showTopLevel ? ["--show-toplevel"] : []),
         ...(args.isInsideWorkTree ? ["--is-inside-work-tree"] : []),
-        ...positionalsWithDelimiter([[args.ref, "ref"]]),
+        ...optionalOperand(args.ref, "ref"),
       ],
     },
     add: {
@@ -324,12 +324,15 @@ export const CLI_OPERATIONS: Record<string, Record<string, CliOperationDefinitio
         },
         ["branch"],
       ),
-      toArgv: (args) => [
-        "switch",
-        ...(args.create ? ["--create"] : []),
-        ...(args.detach ? ["--detach"] : []),
-        ...positionalsWithDelimiter([[requiredString(args, "branch"), "branch"]]),
-      ],
+      toArgv: (args) => {
+        const branch = safeOperand(requiredString(args, "branch"), "branch");
+        return [
+          "switch",
+          ...(args.create ? [`--create=${branch}`] : []),
+          ...(args.detach ? ["--detach"] : []),
+          ...(args.create ? [] : ["--", branch]),
+        ];
+      },
     },
     checkout: {
       effect: "write",
@@ -339,7 +342,7 @@ export const CLI_OPERATIONS: Record<string, Record<string, CliOperationDefinitio
       inputSchema: obj({ branch: s("Branch or tree-ish."), paths: sa("Paths to check out.") }),
       toArgv: (args) => [
         "checkout",
-        ...positionalsWithDelimiter([[args.branch, "branch"]]),
+        ...optionalOperand(args.branch, "branch"),
         ...pathspec(args.paths),
       ],
     },
@@ -373,7 +376,7 @@ export const CLI_OPERATIONS: Record<string, Record<string, CliOperationDefinitio
       toArgv: (args) => [
         "reset",
         ...resetMode(args.mode),
-        ...positionalsWithDelimiter([[args.ref, "ref"]]),
+        ...optionalOperand(args.ref, "ref"),
         ...pathspec(args.paths),
       ],
     },

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -218,6 +218,13 @@ describe("cli command capabilities", () => {
       "--",
       "src/a.ts",
     ]);
+    expect(buildCliArgv("git", "diff", { ref: "HEAD", paths: ["src/a.ts"] })).toEqual([
+      "diff",
+      "--",
+      "HEAD",
+      "--",
+      "src/a.ts",
+    ]);
     expect(buildCliArgv("git", "log", { limit: 3, oneline: true })).toEqual([
       "log",
       "--max-count",
@@ -227,15 +234,15 @@ describe("cli command capabilities", () => {
     expect(buildCliArgv("git", "show", { ref: "HEAD", stat: true })).toEqual([
       "show",
       "--stat",
+      "--",
       "HEAD",
     ]);
     expect(buildCliArgv("git", "remote", { verbose: true })).toEqual(["remote", "-v"]);
-    expect(buildCliArgv("git", "revParse", { ref: "HEAD" })).toEqual(["rev-parse", "HEAD"]);
+    expect(buildCliArgv("git", "revParse", { ref: "HEAD" })).toEqual(["rev-parse", "--", "HEAD"]);
     expect(buildCliArgv("git", "add", { paths: ["src/a.ts"] })).toEqual(["add", "--", "src/a.ts"]);
     expect(buildCliArgv("git", "commit", { message: "feat: add tools" })).toEqual([
       "commit",
-      "-m",
-      "feat: add tools",
+      "--message=feat: add tools",
     ]);
     expect(buildCliArgv("git", "push", { remote: "origin", branch: "main" })).toEqual([
       "push",
@@ -247,10 +254,12 @@ describe("cli command capabilities", () => {
     expect(buildCliArgv("git", "switch", { branch: "feature", create: true })).toEqual([
       "switch",
       "--create",
+      "--",
       "feature",
     ]);
     expect(buildCliArgv("git", "checkout", { branch: "main", paths: ["README.md"] })).toEqual([
       "checkout",
+      "--",
       "main",
       "--",
       "README.md",
@@ -264,27 +273,26 @@ describe("cli command capabilities", () => {
     expect(buildCliArgv("git", "reset", { mode: "soft", ref: "HEAD~1" })).toEqual([
       "reset",
       "--soft",
+      "--",
       "HEAD~1",
     ]);
     expect(buildCliArgv("git", "stash", { command: "push", message: "wip" })).toEqual([
       "stash",
       "push",
-      "-m",
-      "wip",
+      "--message=wip",
     ]);
     expect(buildCliArgv("git", "tag", { name: "v1.0.0", message: "release" })).toEqual([
       "tag",
       "-a",
+      "--message=release",
+      "--",
       "v1.0.0",
-      "-m",
-      "release",
     ]);
     expect(buildCliArgv("gh", "issueView", { number: 13, repo: "owner/repo" })).toEqual([
       "issue",
       "view",
       "13",
-      "--repo",
-      "owner/repo",
+      "--repo=owner/repo",
       "--json",
       "number,title,state,url,body,author,createdAt,updatedAt,labels,assignees,comments",
     ]);
@@ -300,8 +308,7 @@ describe("cli command capabilities", () => {
     ).toEqual([
       "issue",
       "list",
-      "--repo",
-      "owner/repo",
+      "--repo=owner/repo",
       "--state",
       "open",
       "--limit",
@@ -354,18 +361,12 @@ describe("cli command capabilities", () => {
     ).toEqual([
       "issue",
       "create",
-      "--title",
-      "Track CLI discovery",
-      "--body",
-      "Add dynamic discovery.",
-      "--label",
-      "enhancement",
-      "--label",
-      "security",
-      "--assignee",
-      "@me",
-      "--repo",
-      "owner/repo",
+      "--title=Track CLI discovery",
+      "--body=Add dynamic discovery.",
+      "--label=enhancement",
+      "--label=security",
+      "--assignee=@me",
+      "--repo=owner/repo",
     ]);
     expect(
       buildCliArgv("gh", "issueEdit", {
@@ -380,16 +381,11 @@ describe("cli command capabilities", () => {
       "issue",
       "edit",
       "21",
-      "--title",
-      "Updated title",
-      "--body",
-      "Updated body",
-      "--add-label",
-      "enhancement",
-      "--remove-label",
-      "bug",
-      "--repo",
-      "owner/repo",
+      "--title=Updated title",
+      "--body=Updated body",
+      "--add-label=enhancement",
+      "--remove-label=bug",
+      "--repo=owner/repo",
     ]);
     expect(
       buildCliArgv("gh", "issueComment", {
@@ -397,7 +393,7 @@ describe("cli command capabilities", () => {
         body: "Depends on #22.",
         repo: "owner/repo",
       }),
-    ).toEqual(["issue", "comment", "21", "--body", "Depends on #22.", "--repo", "owner/repo"]);
+    ).toEqual(["issue", "comment", "21", "--body=Depends on #22.", "--repo=owner/repo"]);
     expect(buildCliArgv("gh", "issueClose", { number: 22 })).toEqual(["issue", "close", "22"]);
     expect(buildCliArgv("gh", "issueListBlockedBy", { number: 22 })).toEqual([
       "api",
@@ -439,7 +435,7 @@ describe("cli command capabilities", () => {
         comment: "Done in 0efa12b.",
         repo: "owner/repo",
       }),
-    ).toEqual(["issue", "close", "22", "--comment", "Done in 0efa12b.", "--repo", "owner/repo"]);
+    ).toEqual(["issue", "close", "22", "--comment=Done in 0efa12b.", "--repo=owner/repo"]);
     expect(
       buildCliArgv("gh", "labelCreate", {
         name: "security",
@@ -451,18 +447,14 @@ describe("cli command capabilities", () => {
       "label",
       "create",
       "security",
-      "--description",
-      "Security-related work",
-      "--color",
-      "d73a4a",
-      "--repo",
-      "owner/repo",
+      "--description=Security-related work",
+      "--color=d73a4a",
+      "--repo=owner/repo",
     ]);
     expect(buildCliArgv("gh", "labelList", { repo: "owner/repo", limit: 10 })).toEqual([
       "label",
       "list",
-      "--repo",
-      "owner/repo",
+      "--repo=owner/repo",
       "--limit",
       "10",
     ]);
@@ -522,7 +514,31 @@ describe("cli command capabilities", () => {
         vitestPlugin: true,
         paths: ["src"],
       }),
-    ).toEqual(["--deny", "warnings", "--vitest-plugin", "--", "src"]);
+    ).toEqual(["--deny=warnings", "--vitest-plugin", "--", "src"]);
+  });
+
+  test("keeps freeform option values attached without rejecting leading dashes", () => {
+    expect(buildCliArgv("git", "commit", { message: "--author=guest@example.com" })).toEqual([
+      "commit",
+      "--message=--author=guest@example.com",
+    ]);
+    expect(
+      buildCliArgv("gh", "issueCreate", {
+        title: "--title=guest",
+        body: "--body=guest",
+        label: ["--label=guest"],
+        assignee: ["--assignee=guest"],
+        repo: "--repo=guest",
+      }),
+    ).toEqual([
+      "issue",
+      "create",
+      "--title=--title=guest",
+      "--body=--body=guest",
+      "--label=--label=guest",
+      "--assignee=--assignee=guest",
+      "--repo=--repo=guest",
+    ]);
   });
 
   test("fences guest-controlled CLI operands from option parsing", () => {
@@ -582,7 +598,10 @@ describe("cli command capabilities", () => {
     );
 
     expect(result.error).toBeUndefined();
-    expect(JSON.parse(String((result.result as { stdout: string }).stdout))).toEqual(["HEAD"]);
+    expect(JSON.parse(String((result.result as { stdout: string }).stdout))).toEqual([
+      "--",
+      "HEAD",
+    ]);
   });
 
   test("validates runtime argument shapes", () => {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -239,6 +239,7 @@ describe("cli command capabilities", () => {
     ]);
     expect(buildCliArgv("git", "push", { remote: "origin", branch: "main" })).toEqual([
       "push",
+      "--",
       "origin",
       "main",
     ]);
@@ -474,11 +475,21 @@ describe("cli command capabilities", () => {
         hidden: true,
         ignoreCase: true,
       }),
-    ).toEqual(["--ignore-case", "--hidden", "--max-count", "2", "--glob", "*.ts", "TODO", "src"]);
-    expect(buildCliArgv("find", "files", {})).toEqual(["."]);
+    ).toEqual([
+      "--ignore-case",
+      "--hidden",
+      "--max-count",
+      "2",
+      "--glob=*.ts",
+      "-e",
+      "TODO",
+      "--",
+      "src",
+    ]);
+    expect(buildCliArgv("find", "files", {})).toEqual(["--", "."]);
     expect(
       buildCliArgv("find", "files", { path: "src", maxDepth: 3, name: "*.ts", type: "file" }),
-    ).toEqual(["src", "-maxdepth", "3", "-name", "*.ts", "-type", "f"]);
+    ).toEqual(["--", "src", "-maxdepth", "3", "-name", "*.ts", "-type", "f"]);
     expect(buildCliArgv("find", "files", { type: "directory" })).toContain("d");
     expect(
       buildCliArgv("grep", "search", {
@@ -487,29 +498,91 @@ describe("cli command capabilities", () => {
         recursive: true,
         ignoreCase: true,
       }),
-    ).toEqual(["-R", "-i", "x", "src"]);
+    ).toEqual(["-R", "-i", "-e", "x", "--", "src"]);
     expect(buildCliArgv("ls", "list", { all: true, long: true, path: "src" })).toEqual([
       "-a",
       "-l",
+      "--",
       "src",
     ]);
     expect(buildCliArgv("vitest", "run", { paths: ["src/cli.test.ts"], update: true })).toEqual([
       "run",
-      "src/cli.test.ts",
       "--update",
+      "--",
+      "src/cli.test.ts",
     ]);
     expect(buildCliArgv("vitest", "run", { reporter: "json" })).toEqual(["run", "--reporter=json"]);
     expect(buildCliArgv("tsc", "build", {})).toEqual([]);
     expect(buildCliArgv("tsc", "build", { watch: true })).toEqual(["--watch"]);
-    expect(buildCliArgv("oxfmt", "check", { paths: ["."] })).toEqual([".", "--check"]);
-    expect(buildCliArgv("oxfmt", "write", { paths: ["."] })).toEqual([".", "--write"]);
+    expect(buildCliArgv("oxfmt", "check", { paths: ["."] })).toEqual(["--check", "--", "."]);
+    expect(buildCliArgv("oxfmt", "write", { paths: ["."] })).toEqual(["--write", "--", "."]);
     expect(
       buildCliArgv("oxlint", "run", {
         deny: "warnings",
         vitestPlugin: true,
         paths: ["src"],
       }),
-    ).toEqual(["--deny", "warnings", "--vitest-plugin", "src"]);
+    ).toEqual(["--deny", "warnings", "--vitest-plugin", "--", "src"]);
+  });
+
+  test("fences guest-controlled CLI operands from option parsing", () => {
+    expect(buildCliArgv("rg", "search", { pattern: "--pre=/bin/sh", paths: ["src"] })).toEqual([
+      "-e",
+      "--pre=/bin/sh",
+      "--",
+      "src",
+    ]);
+    expect(buildCliArgv("grep", "search", { pattern: "--include=*.ts", paths: ["src"] })).toEqual([
+      "-e",
+      "--include=*.ts",
+      "--",
+      "src",
+    ]);
+
+    expect(() => buildCliArgv("find", "files", { path: "-delete" })).toThrow(
+      "path must not be empty or start with '-'",
+    );
+    expect(() => buildCliArgv("git", "push", { remote: "--receive-pack=/tmp/payload" })).toThrow(
+      "remote must not be empty or start with '-'",
+    );
+    expect(() => buildCliArgv("git", "pull", { branch: "--upload-pack=/tmp/payload" })).toThrow(
+      "branch must not be empty or start with '-'",
+    );
+    expect(() => buildCliArgv("git", "diff", { ref: "--output=/tmp/evil" })).toThrow(
+      "ref must not be empty or start with '-'",
+    );
+    expect(() => buildCliArgv("ls", "list", { path: "--help" })).toThrow(
+      "path must not be empty or start with '-'",
+    );
+    expect(() => buildCliArgv("vitest", "run", { paths: ["--runInBand"] })).toThrow(
+      "paths must not contain empty operands or operands starting with '-'",
+    );
+    expect(() => buildCliArgv("oxfmt", "check", { paths: ["--write"] })).toThrow(
+      "paths must not contain empty operands or operands starting with '-'",
+    );
+    expect(() => buildCliArgv("oxlint", "run", { paths: ["--fix"] })).toThrow(
+      "paths must not contain empty operands or operands starting with '-'",
+    );
+  });
+
+  test("read-only git operations pass fenced operands to the host", async () => {
+    const cwd = tempProject();
+    writeFileSync(
+      join(cwd, "diff"),
+      "process.stdout.write(JSON.stringify(process.argv.slice(2)));\n",
+    );
+    const result = await new QuickJsExecutor({ timeout: 10_000 }).execute(
+      "return await cli.git.diff({ ref: 'HEAD' });",
+      {
+        cli: createCliBindings(
+          { git: { backend: "host", command: process.execPath, operations: ["diff"] } },
+          cwd,
+        ),
+      },
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(JSON.parse(String((result.result as { stdout: string }).stdout))).toEqual(["HEAD"]);
   });
 
   test("validates runtime argument shapes", () => {
@@ -637,20 +710,20 @@ describe("cli command capabilities", () => {
     expect(stderr).toContain("[Output truncated");
   });
 
-  test("host commands receive authentication-related environment", async () => {
+  test("GitHub commands receive authentication-related environment", async () => {
     const cwd = tempProject();
     writeFileSync(
-      join(cwd, "status"),
+      join(cwd, "issue"),
       "process.stdout.write(JSON.stringify({ HOME: process.env.HOME, GH_TOKEN: process.env.GH_TOKEN }));\n",
     );
     const previousToken = process.env.GH_TOKEN;
     process.env.GH_TOKEN = "test-token";
     try {
       const result = await new QuickJsExecutor({ timeout: 10_000 }).execute(
-        "return await cli.git.status({});",
+        "return await cli.gh.issueView({ number: 1 });",
         {
           cli: createCliBindings(
-            { git: { backend: "host", command: process.execPath, operations: ["status"] } },
+            { gh: { backend: "host", command: process.execPath, operations: ["issueView"] } },
             cwd,
           ),
         },
@@ -664,6 +737,37 @@ describe("cli command capabilities", () => {
     } finally {
       if (previousToken === undefined) delete process.env.GH_TOKEN;
       else process.env.GH_TOKEN = previousToken;
+    }
+  });
+
+  test("non-GitHub host commands do not receive GitHub tokens", async () => {
+    const cwd = tempProject();
+    writeFileSync(
+      join(cwd, "status"),
+      "process.stdout.write(JSON.stringify({ GH_TOKEN: process.env.GH_TOKEN, GITHUB_TOKEN: process.env.GITHUB_TOKEN }));\n",
+    );
+    const previousGhToken = process.env.GH_TOKEN;
+    const previousGithubToken = process.env.GITHUB_TOKEN;
+    process.env.GH_TOKEN = "test-gh-token";
+    process.env.GITHUB_TOKEN = "test-github-token";
+    try {
+      const result = await new QuickJsExecutor({ timeout: 10_000 }).execute(
+        "return await cli.git.status({});",
+        {
+          cli: createCliBindings(
+            { git: { backend: "host", command: process.execPath, operations: ["status"] } },
+            cwd,
+          ),
+        },
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(JSON.parse(String((result.result as { stdout: string }).stdout))).toEqual({});
+    } finally {
+      if (previousGhToken === undefined) delete process.env.GH_TOKEN;
+      else process.env.GH_TOKEN = previousGhToken;
+      if (previousGithubToken === undefined) delete process.env.GITHUB_TOKEN;
+      else process.env.GITHUB_TOKEN = previousGithubToken;
     }
   });
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -220,7 +220,6 @@ describe("cli command capabilities", () => {
     ]);
     expect(buildCliArgv("git", "diff", { ref: "HEAD", paths: ["src/a.ts"] })).toEqual([
       "diff",
-      "--",
       "HEAD",
       "--",
       "src/a.ts",
@@ -234,11 +233,10 @@ describe("cli command capabilities", () => {
     expect(buildCliArgv("git", "show", { ref: "HEAD", stat: true })).toEqual([
       "show",
       "--stat",
-      "--",
       "HEAD",
     ]);
     expect(buildCliArgv("git", "remote", { verbose: true })).toEqual(["remote", "-v"]);
-    expect(buildCliArgv("git", "revParse", { ref: "HEAD" })).toEqual(["rev-parse", "--", "HEAD"]);
+    expect(buildCliArgv("git", "revParse", { ref: "HEAD" })).toEqual(["rev-parse", "HEAD"]);
     expect(buildCliArgv("git", "add", { paths: ["src/a.ts"] })).toEqual(["add", "--", "src/a.ts"]);
     expect(buildCliArgv("git", "commit", { message: "feat: add tools" })).toEqual([
       "commit",
@@ -251,15 +249,17 @@ describe("cli command capabilities", () => {
       "main",
     ]);
     expect(buildCliArgv("git", "pull", { rebase: true })).toEqual(["pull", "--rebase"]);
-    expect(buildCliArgv("git", "switch", { branch: "feature", create: true })).toEqual([
+    expect(buildCliArgv("git", "switch", { branch: "feature" })).toEqual([
       "switch",
-      "--create",
       "--",
       "feature",
     ]);
+    expect(buildCliArgv("git", "switch", { branch: "feature", create: true })).toEqual([
+      "switch",
+      "--create=feature",
+    ]);
     expect(buildCliArgv("git", "checkout", { branch: "main", paths: ["README.md"] })).toEqual([
       "checkout",
-      "--",
       "main",
       "--",
       "README.md",
@@ -273,7 +273,6 @@ describe("cli command capabilities", () => {
     expect(buildCliArgv("git", "reset", { mode: "soft", ref: "HEAD~1" })).toEqual([
       "reset",
       "--soft",
-      "--",
       "HEAD~1",
     ]);
     expect(buildCliArgv("git", "stash", { command: "push", message: "wip" })).toEqual([
@@ -598,10 +597,7 @@ describe("cli command capabilities", () => {
     );
 
     expect(result.error).toBeUndefined();
-    expect(JSON.parse(String((result.result as { stdout: string }).stdout))).toEqual([
-      "--",
-      "HEAD",
-    ]);
+    expect(JSON.parse(String((result.result as { stdout: string }).stdout))).toEqual(["HEAD"]);
   });
 
   test("validates runtime argument shapes", () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -186,7 +186,7 @@ function executeHost(
   signal?: AbortSignal,
 ): Promise<CommandResult> {
   return new Promise((resolve, reject) => {
-    const child = spawn(command, args, { cwd, env: hostCommandEnv(), signal });
+    const child = spawn(command, args, { cwd, env: hostCommandEnv(toolName), signal });
     let stdout = "";
     let stderr = "";
     const timer = setTimeout(() => {
@@ -222,15 +222,18 @@ function executeHost(
   });
 }
 
-function hostCommandEnv(): NodeJS.ProcessEnv {
-  return {
+function hostCommandEnv(toolName: string): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {
     PATH: process.env.PATH ?? "",
     HOME: process.env.HOME,
     XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME,
-    GH_TOKEN: process.env.GH_TOKEN,
-    GITHUB_TOKEN: process.env.GITHUB_TOKEN,
-    GITHUB_HOST: process.env.GITHUB_HOST,
   };
+  if (toolName === "gh") {
+    env.GH_TOKEN = process.env.GH_TOKEN;
+    env.GITHUB_TOKEN = process.env.GITHUB_TOKEN;
+    env.GITHUB_HOST = process.env.GITHUB_HOST;
+  }
+  return env;
 }
 
 const HOST_MAX_OUTPUT_BYTES = 50 * 1024;


### PR DESCRIPTION
Closes #68

## Summary

Guest-controlled operands for the curated host CLI operations were appended directly to argv. Values beginning with `-` could therefore be reinterpreted as options by read-oriented helpers such as `rg`, `find`, and `git`, including the documented `rg --pre`, `find -delete`, `git --receive-pack`, and `git --output` proof of concepts.

This PR:

- rejects empty and leading-dash values used as paths, refs, remotes, branches, tags, and other positional operands;
- passes `rg` and `grep` patterns through `-e`;
- terminates option parsing before path operands and fences Git push/pull positionals with `--`;
- places `vitest`, `oxfmt`, and `oxlint` paths after `--`;
- keeps GitHub authentication variables limited to `gh` host commands; and
- adds regression coverage for the reported proof of concepts and host argv/environment behavior.

## Compatibility

Valid non-option operands keep their existing meaning. The argv layout now uses the standard `--` delimiter for path and Git push/pull operands, and `rg`/`grep` patterns are passed explicitly as pattern values. Empty or leading-dash positional operands are rejected before a host process starts. GitHub token variables are no longer exposed to non-`gh` host commands.

## Verification

In a Linux Node 24 temporary copy with the repository line endings normalized:

- `npm run format:check` — passed
- `npm run lint` — passed
- `npm run build` — passed
- `npm test -- --testTimeout=60000` — 308 passed, 3 skipped across 19 test files
- `git diff --check` — passed

The focused security tests in `src/cli.test.ts` also pass locally: 5 passed. The default Windows run has unrelated repository baseline limitations: the existing integration tests invoke Unix `sh`, and the package hygiene test can exceed Vitest's 10-second timeout on a Windows-mounted temporary tree. The Linux run above uses the repository's existing test suite and raises only that environment-sensitive timeout; no production timeout or test behavior was changed.

## AI disclosure

This change was implemented with assistance from OpenAI Codex. The final diff and verification results were reviewed before submission.
